### PR TITLE
Core Hashing module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vscode
+/vendor

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/dhruvil/ribbon
+
+go 1.25
+
+require github.com/zeebo/xxh3 v1.1.0
+
+require (
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hash.go
+++ b/hash.go
@@ -1,0 +1,489 @@
+package ribbon
+
+import (
+	"math/bits"
+
+	"github.com/zeebo/xxh3"
+)
+
+// =============================================================================
+// CONSTANTS — hash pipeline multipliers and seed-mixing parameters
+// =============================================================================
+
+const (
+	// kRehashFactor: large prime multiplier for seed remixing.
+	// When the banding algorithm retries with a new seed, each stored hash
+	// must produce a fresh (start, coeff, result) triple. Simple XOR-and-
+	// multiply ensures sufficient diffusion:
+	//   rehashed = (storedHash ^ rawSeed) * kRehashFactor
+	//
+	// [RocksDB: StandardRehasherAdapter::HashFn]
+	kRehashFactor uint64 = 0x6193d459236a3a0d
+
+	// kCoeffAndResultFactor: multiplier that derives coefficient and result
+	// rows from a rehashed hash. The start position depends on the high bits
+	// of the rehashed hash (via fastRange64). To ensure the coefficient row
+	// and result row are statistically independent of start, we multiply by
+	// a different large prime — this redistributes the bit dependencies.
+	//
+	// Paper §2: "each key x is assigned a start position s(x) and a
+	// coefficient row c(x) ∈ {0,1}^w" — s, c, and result must be
+	// pairwise independent derivations from the same hash.
+	//
+	// [RocksDB: kCoeffAndResultFactor in StandardHasher]
+	kCoeffAndResultFactor uint64 = 0xc28f82822b650bed
+
+	// kCoeffXor64: XOR constant for 64→128 bit expansion of coefficient row.
+	// When w=128, a single 64-bit hash must fill 128 coefficient bits.
+	// XOR-folding with a non-zero constant ensures:
+	//   (a) upper and lower halves are not identical,
+	//   (b) the result is guaranteed non-zero (if a==0 then lo = kCoeffXor64 ≠ 0).
+	kCoeffXor64 uint64 = 0xc367844a6e52731d
+
+	// Seed premixing constants (ordinal seed ↔ raw seed conversion).
+	// The filter stores only a small ordinal (e.g., 0..255) to identify
+	// which seed succeeded. Bijective mixing converts these sequential
+	// ordinals into well-distributed 64-bit raw seeds, so that consecutive
+	// seeds produce maximally different hash remixings.
+	kSeedMixMask       uint64 = 0xf0f0f0f0f0f0f0f0
+	kSeedMixShift      uint   = 4
+	kToRawSeedFactor   uint64 = 0xc78219a23eeadd03
+	kFromRawSeedFactor uint64 = 0xfe1a137d14b475ab
+)
+
+// =============================================================================
+// PACKAGE-LEVEL UTILITIES
+// =============================================================================
+
+// ordinalSeedToRaw converts a small ordinal seed (e.g., 0..255) to a raw seed
+// with good bit distribution.
+//
+// The Ribbon construction retries with a new hash seed when banding fails
+// (paper §2). Only the successful seed ordinal is stored in the serialized
+// filter — this bijective mixing ensures sequential ordinals produce
+// maximally different raw seeds for independent rehashing.
+//
+//	raw = ordinal * kToRawSeedFactor
+//	raw ^= (raw & kSeedMixMask) >> kSeedMixShift
+func ordinalSeedToRaw(ordinal uint32) uint64 {
+	raw := uint64(ordinal) * kToRawSeedFactor
+	raw ^= (raw & kSeedMixMask) >> kSeedMixShift
+	return raw
+}
+
+// rawSeedToOrdinal converts a raw seed back to an ordinal seed.
+// Inverse of ordinalSeedToRaw — used to recover the stored ordinal
+// from the internal raw seed state.
+func rawSeedToOrdinal(raw uint64) uint32 {
+	tmp := raw
+	tmp ^= (tmp & kSeedMixMask) >> kSeedMixShift
+	return uint32(tmp * kFromRawSeedFactor)
+}
+
+// fastRange64 maps a 64-bit hash uniformly into [0, rangeVal) without modulo
+// bias, using 128-bit multiply: (uint128(hash) * rangeVal) >> 64.
+//
+// This is faster than h % rangeVal and has no bias for power-of-2 ranges.
+// It depends primarily on the high bits of hash, which is important because
+// getCoeffRow and getResultRow consume the low/middle bits of the same
+// rehashed hash — using high bits for start avoids correlation.
+//
+// [RocksDB: FastRangeGeneric]
+func fastRange64(hash uint64, rangeVal uint32) uint32 {
+	hi, _ := bits.Mul64(uint64(rangeVal), hash)
+	return uint32(hi)
+}
+
+// =============================================================================
+// HASH RESULT
+// =============================================================================
+
+// hashResult holds all values derived from hashing a key for banding.
+// This is the output of the full two-phase hash pipeline.
+type hashResult struct {
+	start    uint32  // start position in [0, numStarts)
+	coeffRow uint128 // w-bit coefficient bitmask
+	result   uint8   // r-bit fingerprint
+}
+
+// =============================================================================
+// HASHER INTERFACE
+// =============================================================================
+
+// hasher defines the interface for Ribbon filter hash operations.
+//
+// Per §2 of Dillinger & Walzer (2021), each key must be mapped to a triple
+// (start, coefficients, result) for the banding linear system. This mapping
+// uses a two-phase pipeline to support efficient seed retries:
+//
+//	Phase 1 (once per key):       Key → 64-bit hash (stored for reuse)
+//	Phase 2 (per seed attempt):   stored hash → rehash → (start, coeffRow, result)
+//
+// Custom hash strategies can be plugged in by implementing this interface.
+//
+// [RocksDB: StandardHasher<TypesAndSettings>]
+//
+// Typical usage:
+//
+//	h := newStandardHasher(128, numStarts, 7, true)
+//
+//	// Phase 1: hash keys once
+//	hashes := make([]uint64, len(keys))
+//	for i, key := range keys {
+//	    hashes[i] = h.keyHash(key)
+//	}
+//
+//	// Phase 2: try seeds until banding succeeds
+//	for seed := uint32(0); ; seed++ {
+//	    h.setOrdinalSeed(seed)
+//	    for _, hash := range hashes {
+//	        hr := h.derive(hash)
+//	        // use hr.start, hr.coeffRow, hr.result for banding
+//	    }
+//	}
+type hasher interface {
+	// keyHash computes the initial 64-bit hash of a raw key (Phase 1).
+	// Called once per key; the result is stored and reused across seed attempts.
+	keyHash(key []byte) uint64
+
+	// setOrdinalSeed sets the hash seed from a small ordinal value (0..255).
+	// Internally converts to a well-distributed raw seed.
+	setOrdinalSeed(ordinal uint32)
+
+	// getOrdinalSeed returns the current ordinal seed.
+	getOrdinalSeed() uint32
+
+	// setNumStarts updates the number of valid start positions.
+	// numStarts = numSlots - coeffBits + 1
+	setNumStarts(numStarts uint32)
+
+	// getNumStarts returns the current number of valid start positions.
+	getNumStarts() uint32
+
+	// getCoeffBits returns the ribbon width w (32, 64, or 128).
+	getCoeffBits() uint32
+
+	// getResultBits returns the number of fingerprint bits used.
+	getResultBits() uint
+
+	// firstCoeffAlwaysOne returns whether bit 0 of the coefficient row is
+	// always forced to 1. When true, the banding algorithm can skip the
+	// leading-zero scan (faster construction). When false, the coefficient
+	// row is still guaranteed non-zero through other means.
+	firstCoeffAlwaysOne() bool
+
+	// rehash mixes a pre-computed 64-bit hash with the current raw seed.
+	// This is the core of Phase 2 — produces a new hash for deriving
+	// start/coeff/result. Called once per key per seed attempt.
+	rehash(h uint64) uint64
+
+	// getStart computes the start slot index from a rehashed hash.
+	// Returns a value in [0, numStarts).
+	getStart(h uint64) uint32
+
+	// getCoeffRow derives the w-bit coefficient row from a rehashed hash.
+	// If firstCoeffAlwaysOne is true, bit 0 is forced to 1.
+	// The returned row is always non-zero (required for banding).
+	getCoeffRow(h uint64) uint128
+
+	// getResultRow derives the r-bit fingerprint from a rehashed hash.
+	// The result is masked to the configured number of result bits.
+	getResultRow(h uint64) uint8
+
+	// derive rehashes a stored hash with the current seed and returns
+	// the complete (start, coeffRow, result) triple for banding.
+	derive(h uint64) hashResult
+}
+
+// =============================================================================
+// STANDARD HASHER — implementation
+// =============================================================================
+
+// standardHasher implements the hasher interface.
+//
+// It realises the two-phase hash pipeline described in §2 of Dillinger &
+// Walzer (2021), where each key is hashed once (Phase 1) and the stored hash
+// is cheaply remixed per seed attempt (Phase 2) to produce the
+// (start, coefficients, result) triple for banding.
+//
+// Configurable parameters (paper §2 & §4):
+//   - coeffBits (w): ribbon width — 32, 64, or 128.
+//     Overhead ratio m/n ≈ 1 + 2.3/w; larger w = less space, slower build.
+//   - resultBits (r): fingerprint bits stored per key. FPR ≈ 2^(−r).
+//   - forceFirstCoeff: when true, bit 0 of every coefficient row is forced
+//     to 1, so the Gaussian elimination pivot is always at column "start"
+//     — no leading-zero scan needed (faster construction). When false, the
+//     row is still guaranteed non-zero through other means.
+//
+// Hash pipeline:
+//
+//	Phase 1: key → XXH3_64bits(key, seed=0) → stored uint64 hash
+//	Phase 2: (hash ^ rawSeed) * kRehashFactor → rehashed
+//	  ├─ start:    fastRange64(rehashed, numStarts)     [high bits]
+//	  ├─ coeffRow: multiply → expand/truncate to w bits  [low/middle bits]
+//	  └─ result:   multiply → bswap64 → mask to r bits   [byte-swapped]
+//
+// [RocksDB: StandardHasher<TypesAndSettings>]
+type standardHasher struct {
+	rawSeed         uint64
+	numStarts       uint32
+	coeffBits       uint32 // ribbon width w: 32, 64, or 128
+	resultBits      uint
+	resultMask      uint8 // pre-computed: (1 << resultBits) - 1
+	forceFirstCoeff bool  // force LSB=1 in coefficient rows
+
+	// Pre-computed coefficient derivation masks (set once in constructor).
+	// These replace the per-call switch on coeffBits in derive(), making
+	// the coefficient path branchless and keeping derive() inlineable.
+	//
+	//   w=32:  coeffLoMask=0x00000000FFFFFFFF  coeffHiMask=0  coeffXor=0
+	//   w=64:  coeffLoMask=0xFFFFFFFFFFFFFFFF  coeffHiMask=0  coeffXor=0
+	//   w=128: coeffLoMask=0xFFFFFFFFFFFFFFFF  coeffHiMask=^0 coeffXor=kCoeffXor64
+	coeffLoMask uint64 // truncation mask for lo half of coefficient row
+	coeffHiMask uint64 // 0 for w≤64, ^0 for w=128 (enables hi = a)
+	coeffXor    uint64 // 0 for w≤64, kCoeffXor64 for w=128 (XOR expansion)
+	coeffOrMask uint64 // 1 if forceFirstCoeff, 0 otherwise (branchless LSB set)
+}
+
+// Compile-time check: *standardHasher implements hasher.
+var _ hasher = (*standardHasher)(nil)
+
+// newStandardHasher creates a Ribbon filter hasher with the given configuration.
+//
+// Parameters:
+//   - coeffBits: ribbon width w — must be 32, 64, or 128.
+//     Paper §4: overhead ratio m/n ≈ 1 + 2.3/w. Larger w saves space but
+//     increases construction time per key.
+//   - numStarts: number of valid start positions (= numSlots − w + 1).
+//     Paper §2: "each key x is assigned a start position s(x) ∈ {0,…,m−w}".
+//   - resultBits: fingerprint bits r. FPR ≈ 2^(−r) (paper §3).
+//   - firstCoeffAlwaysOne: when true, bit 0 of every coefficient row is
+//     forced to 1, so the banding pivot is deterministic at column s(x).
+//     Set to false for research/experimentation with natural coefficient
+//     distributions.
+//
+// Panics if coeffBits is not 32, 64, or 128.
+func newStandardHasher(coeffBits uint32, numStarts uint32, resultBits uint, firstCoeffAlwaysOne bool) *standardHasher {
+	var coeffLoMask, coeffHiMask, coeffXor uint64
+	switch coeffBits {
+	case 32:
+		coeffLoMask = 0x00000000FFFFFFFF
+	case 64:
+		coeffLoMask = ^uint64(0)
+	case 128:
+		coeffLoMask = ^uint64(0)
+		coeffHiMask = ^uint64(0)
+		coeffXor = kCoeffXor64
+	default:
+		panic("ribbon: coeffBits must be 32, 64, or 128")
+	}
+	var coeffOrMask uint64
+	if firstCoeffAlwaysOne {
+		coeffOrMask = 1
+	}
+	return &standardHasher{
+		numStarts:       numStarts,
+		coeffBits:       coeffBits,
+		resultBits:      resultBits,
+		resultMask:      uint8((1 << resultBits) - 1),
+		forceFirstCoeff: firstCoeffAlwaysOne,
+		coeffLoMask:     coeffLoMask,
+		coeffHiMask:     coeffHiMask,
+		coeffXor:        coeffXor,
+		coeffOrMask:     coeffOrMask,
+	}
+}
+
+// --- Phase 1: Key → 64-bit hash ---
+
+// keyHash computes the initial 64-bit hash of a key using XXH3 (Phase 1).
+//
+// This is the only step that touches the raw key bytes. The 64-bit output
+// is stored and reused across all seed attempts, amortising the cost of
+// hashing over retries (paper §2).
+//
+// NOTE: we use the final XXH3 spec (via zeebo/xxh3). This is NOT byte-
+// compatible with RocksDB's XXPH3 (preview v0.7.2), which is fine for a
+// standalone implementation — compatibility would only matter for reading
+// RocksDB's on-disk filter blocks.
+func (sh *standardHasher) keyHash(key []byte) uint64 {
+	return xxh3.Hash(key)
+}
+
+// --- Seed management ---
+
+// setOrdinalSeed sets the seed from a small ordinal (typically 0..255).
+// Converts the ordinal to a well-distributed raw seed via bijective mixing.
+// The filter serializes only this small ordinal, not the full 64-bit raw seed.
+func (sh *standardHasher) setOrdinalSeed(ordinal uint32) {
+	sh.rawSeed = ordinalSeedToRaw(ordinal)
+}
+
+// getOrdinalSeed returns the current ordinal seed by inverting the raw seed.
+func (sh *standardHasher) getOrdinalSeed() uint32 {
+	return rawSeedToOrdinal(sh.rawSeed)
+}
+
+// --- Configuration accessors ---
+
+// setNumStarts updates the number of valid start positions.
+// numStarts = numSlots - coeffBits + 1.
+// Call this when the filter size changes.
+func (sh *standardHasher) setNumStarts(numStarts uint32) {
+	sh.numStarts = numStarts
+}
+
+// getNumStarts returns the current number of valid start positions.
+func (sh *standardHasher) getNumStarts() uint32 {
+	return sh.numStarts
+}
+
+// getCoeffBits returns the ribbon width w.
+func (sh *standardHasher) getCoeffBits() uint32 {
+	return sh.coeffBits
+}
+
+// getResultBits returns the number of fingerprint bits.
+func (sh *standardHasher) getResultBits() uint {
+	return sh.resultBits
+}
+
+// firstCoeffAlwaysOne returns whether bit 0 of coefficient rows is forced to 1.
+func (sh *standardHasher) firstCoeffAlwaysOne() bool {
+	return sh.forceFirstCoeff
+}
+
+// --- Phase 2: Rehash + derive ---
+
+// rehash mixes a stored hash with the current raw seed (Phase 2 entry point).
+//
+//	rehashed = (storedHash ^ rawSeed) * kRehashFactor
+//
+// The Ribbon construction retries banding with a new seed on failure
+// (paper §2). rehash is the cheapest possible remixing: XOR injects the
+// seed, and the multiply provides good high-bit diffusion for fastRange64.
+// The raw seed is already pre-mixed (via ordinalSeedToRaw), so sequential
+// ordinals produce well-separated rehash outputs.
+func (sh *standardHasher) rehash(h uint64) uint64 {
+	return (h ^ sh.rawSeed) * kRehashFactor
+}
+
+// getStart computes the start position s(x) from a rehashed hash.
+//
+// Paper §2: "each key x is assigned a start position s(x) ∈ {0,…,m−w}"
+// where m−w+1 = numStarts. We use fastRange64 (high-bit-dependent) so that
+// start is statistically independent from the coefficient and result rows
+// derived from the same hash's low/middle bits.
+func (sh *standardHasher) getStart(h uint64) uint32 {
+	return fastRange64(h, sh.numStarts)
+}
+
+// getCoeffRow derives the w-bit coefficient row c(x) from a rehashed hash.
+//
+// Paper §2: "each key x is assigned … a coefficient row c(x) ∈ {0,1}^w".
+// The coefficient row must be (a) non-zero (otherwise the linear system row
+// is trivial and cannot encode information) and (b) independent of start.
+//
+// We multiply by kCoeffAndResultFactor (a different prime than kRehashFactor)
+// to redistribute bit dependencies away from the high bits that getStart
+// already consumed. The derivation then depends on w:
+//
+//	w=32:  truncate the 64-bit product to 32 bits.
+//	w=64:  use the full 64-bit product.
+//	w=128: XOR-fold the 64-bit product into 128 bits:
+//	       {hi: a, lo: a ^ kCoeffXor64}. This guarantees non-zero output
+//	       (kCoeffXor64 ≠ 0 ⇒ if a==0 then lo≠0, if a≠0 then hi≠0) and
+//	       avoids identical upper/lower halves.
+//
+// When forceFirstCoeff is true, bit 0 is unconditionally set to 1. This
+// makes the Gaussian elimination pivot deterministic at column s(x),
+// removing the need for a leading-zero scan during banding (paper §4).
+//
+// Non-zero guarantee: when forceFirstCoeff is false, the branchless path
+// could theoretically produce a zero row (P ≈ 2^-w for w≤64; impossible
+// for w=128 due to XOR expansion). A cold zero-guard catches this.
+//
+// Implementation: uses the same pre-computed masks as derive() — the
+// per-width switch is replaced by branchless mask/XOR/OR operations,
+// and the forceFirstCoeff branch is replaced by coeffOrMask.
+func (sh *standardHasher) getCoeffRow(h uint64) uint128 {
+	a := h * kCoeffAndResultFactor
+	cr := uint128{
+		hi: a & sh.coeffHiMask,
+		lo: (a & sh.coeffLoMask) ^ sh.coeffXor | sh.coeffOrMask,
+	}
+	// Zero guard for standalone callers: if forceFirstCoeff is false and
+	// the branchless path produces an all-zero row, force it to 1.
+	// When forceFirstCoeff is true, coeffOrMask=1 ensures cr.lo≥1.
+	// When w=128, XOR expansion ensures at least one half is non-zero.
+	// Only reachable for w≤64 with !forceFirstCoeff at P≈2^(-w).
+	if cr.lo == 0 && cr.hi == 0 {
+		cr.lo = 1
+	}
+	return cr
+}
+
+// getResultRow derives the r-bit fingerprint from a rehashed hash.
+//
+// Paper §3: when used as a filter, each key's result row is a hash-derived
+// r-bit fingerprint. The FPR for non-member keys is ≈ 2^(−r).
+//
+// Derivation:
+//  1. a = h * kCoeffAndResultFactor  (same multiply as getCoeffRow)
+//  2. Byte-swap a — moves the highest-quality bits (affected most by
+//     the multiply's carry chain) into the lowest byte position, from
+//     which we extract r bits.
+//  3. Mask to resultBits.
+func (sh *standardHasher) getResultRow(h uint64) uint8 {
+	a := h * kCoeffAndResultFactor
+	swapped := bits.ReverseBytes64(a)
+	return uint8(swapped) & sh.resultMask
+}
+
+// derive rehashes a stored hash with the current seed and returns the
+// complete (start, coeffRow, result) triple needed by the banding algorithm.
+//
+// Paper §2: for each key, the banding step inserts a row into the m × w
+// coefficient matrix at position s(x), with coefficient bits c(x) and
+// target result r(x). This function computes all three from one stored hash.
+//
+// Performance: this method manually inlines rehash, getStart, getCoeffRow,
+// and getResultRow for two reasons:
+//
+//	(a) The multiply h*kCoeffAndResultFactor is shared between getCoeffRow
+//	    and getResultRow — inlining lets us compute it once instead of twice.
+//	(b) The per-width switch in getCoeffRow is replaced by pre-computed
+//	    masks (coeffLoMask, coeffHiMask, coeffXor), and the forceFirstCoeff
+//	    branch is replaced by a pre-computed OR mask (coeffOrMask), making
+//	    the entire coefficient path branchless. This brings the compiler's
+//	    inlining cost under budget 80, so derive() itself is inlined into
+//	    the caller's hot loop (banding), removing one more call/return.
+//
+// Note: the zero-guard for !forceFirstCoeff is omitted here because:
+//   - P(zero coeff) ≈ 2^-64 for w=64, 2^-32 for w=32, 0 for w=128.
+//   - If it occurs, the banding algorithm treats the degenerate row as a
+//     failure and retries with a new seed — no correctness issue.
+//   - The individual getCoeffRow() method retains the guard for callers
+//     who use it outside the banding loop.
+func (sh *standardHasher) derive(h uint64) hashResult {
+	// --- inline rehash ---
+	rh := (h ^ sh.rawSeed) * kRehashFactor
+
+	// --- shared multiply (coeff + result) ---
+	a := rh * kCoeffAndResultFactor
+
+	// --- inline getStart (fastRange64) ---
+	startHi, _ := bits.Mul64(uint64(sh.numStarts), rh)
+
+	// --- inline getCoeffRow (fully branchless) ---
+	var cr uint128
+	cr.hi = a & sh.coeffHiMask
+	cr.lo = (a & sh.coeffLoMask) ^ sh.coeffXor | sh.coeffOrMask
+
+	// --- inline getResultRow (reuses `a` — no second multiply) ---
+	return hashResult{
+		start:    uint32(startHi),
+		coeffRow: cr,
+		result:   uint8(bits.ReverseBytes64(a)) & sh.resultMask,
+	}
+}

--- a/hash_bench_test.go
+++ b/hash_bench_test.go
@@ -1,0 +1,373 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// Benchmarks — hash pipeline hot path
+//
+// The derive() function is the innermost loop of both banding (construction)
+// and seed-retry. Every key passes through it once per seed attempt:
+//
+//   for _, h := range storedHashes { hr := hasher.derive(h) }
+//
+// Therefore its throughput directly determines construction speed.
+//
+// We benchmark:
+//   1. derive()       — full pipeline (rehash → start + coeff + result)
+//   2. rehash()       — seed remixing in isolation
+//   3. getStart()     — fastRange64 mapping
+//   4. getCoeffRow()  — coefficient derivation (width-dependent)
+//   5. getResultRow() — fingerprint extraction
+//   6. keyHash()      — Phase 1 (XXH3), for reference
+//
+// Each is measured across ribbon widths (32/64/128), with and without
+// firstCoeffAlwaysOne, to surface any width-dependent cost.
+// =============================================================================
+
+// precomputedHashes generates N deterministic 64-bit hashes to feed into
+// Phase 2 benchmarks, removing XXH3 from the measured path.
+func precomputedHashes(h *standardHasher, n int) []uint64 {
+	hashes := make([]uint64, n)
+	for i := range hashes {
+		hashes[i] = h.keyHash([]byte(fmt.Sprintf("bench_key_%d", i)))
+	}
+	return hashes
+}
+
+// ---------------------------------------------------------------------------
+// 1. derive — full pipeline
+//
+// Full Phase 2 pipeline: rehash → getStart + getCoeffRow + getResultRow.
+// This is the per-key cost on every seed attempt during banding.
+//
+// derive() is hand-inlined and branchless (no switch, no if). The compiler
+// inlines it into the caller (cost 67, budget 80), so the benchmark loop
+// runs the entire pipeline without a function-call boundary.
+//
+// Optimisations applied:
+//   (a) Single h*kCoeffAndResultFactor multiply shared by coeff and result.
+//   (b) Per-width switch replaced by pre-computed masks (coeffLoMask,
+//       coeffHiMask, coeffXor) — branchless coefficient derivation.
+//   (c) forceFirstCoeff branch replaced by pre-computed coeffOrMask.
+//   (d) resultBits shift replaced by pre-computed resultMask.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   fcao     ns/op   allocs/op
+//   ─────   ─────    ─────   ─────────
+//   w=32    true      0.39   0
+//   w=32    false     0.39   0
+//   w=64    true      0.39   0
+//   w=64    false     0.39   0
+//   w=128   true      0.39   0
+//   w=128   false     0.39   0
+//
+// Key observations:
+//   • ~0.39 ns/key with zero allocations — fully inlined, branchless.
+//   • All widths identical (masks absorb the width difference).
+//   • 6.9× faster than the pre-optimisation baseline of ~2.7 ns/key.
+// ---------------------------------------------------------------------------
+
+func BenchmarkDerive(b *testing.B) {
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			b.Run(name, func(b *testing.B) {
+				h := newStandardHasher(w, 10000, 7, fcao)
+				h.setOrdinalSeed(0)
+				hashes := precomputedHashes(h, 4096)
+				mask := len(hashes) - 1 // power-of-2 for cheap modulo
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink hashResult
+				for i := 0; i < b.N; i++ {
+					sink = h.derive(hashes[i&mask])
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. rehash — seed remixing
+//
+// Isolated cost of (hash ^ rawSeed) * kRehashFactor.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   ns/op   allocs/op
+//   ─────   ─────────
+//   0.39    0
+//
+// Key observation: single multiply — sub-nanosecond, fully inlined.
+// ---------------------------------------------------------------------------
+
+func BenchmarkRehash(b *testing.B) {
+	h := newStandardHasher(128, 10000, 7, true)
+	h.setOrdinalSeed(0)
+	hashes := precomputedHashes(h, 4096)
+	mask := len(hashes) - 1
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var sink uint64
+	for i := 0; i < b.N; i++ {
+		sink = h.rehash(hashes[i&mask])
+	}
+	_ = sink
+}
+
+// ---------------------------------------------------------------------------
+// 3. getStart — fastRange64
+//
+// Maps a 64-bit hash uniformly into [0, numStarts) via 128-bit multiply.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   ns/op   allocs/op
+//   ─────   ─────────
+//   0.40    0
+//
+// Key observation: single math/bits.Mul64 — sub-nanosecond, fully inlined.
+// ---------------------------------------------------------------------------
+
+func BenchmarkGetStart(b *testing.B) {
+	h := newStandardHasher(128, 10000, 7, true)
+	h.setOrdinalSeed(0)
+	hashes := precomputedHashes(h, 4096)
+	mask := len(hashes) - 1
+
+	// Pre-rehash so we measure getStart in isolation
+	rehashed := make([]uint64, len(hashes))
+	for i, kh := range hashes {
+		rehashed[i] = h.rehash(kh)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var sink uint32
+	for i := 0; i < b.N; i++ {
+		sink = h.getStart(rehashed[i&mask])
+	}
+	_ = sink
+}
+
+// ---------------------------------------------------------------------------
+// 4. getCoeffRow — width-dependent coefficient derivation
+//
+// Derives the w-bit coefficient row from a rehashed hash. Contains a
+// 3-way switch on w and an optional |=1 for forceFirstCoeff.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   fcao     ns/op   allocs/op
+//   ─────   ─────    ─────   ─────────
+//   w=32    true      0.39   0
+//   w=32    false     0.39   0
+//   w=64    true      0.39   0
+//   w=64    false     0.39   0
+//   w=128   true      0.39   0
+//   w=128   false     0.39   0
+//
+// Key observations:
+//   • All widths identical — the switch is branch-predicted perfectly
+//     because the width is fixed for the hasher's lifetime.
+//   • fcao adds no measurable cost.
+// ---------------------------------------------------------------------------
+
+func BenchmarkGetCoeffRow(b *testing.B) {
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			b.Run(name, func(b *testing.B) {
+				h := newStandardHasher(w, 10000, 7, fcao)
+				h.setOrdinalSeed(0)
+				hashes := precomputedHashes(h, 4096)
+				mask := len(hashes) - 1
+
+				rehashed := make([]uint64, len(hashes))
+				for i, kh := range hashes {
+					rehashed[i] = h.rehash(kh)
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink uint128
+				for i := 0; i < b.N; i++ {
+					sink = h.getCoeffRow(rehashed[i&mask])
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. getResultRow — fingerprint extraction
+//
+// Derives the r-bit fingerprint: multiply → byte-swap → mask.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   r-bits   ns/op   allocs/op
+//   ──────   ─────   ─────────
+//   r=1      0.39    0
+//   r=7      0.40    0
+//   r=8      0.39    0
+//
+// Key observation: identical cost regardless of r — the mask is a
+// constant after construction, so there is no branch on r.
+// ---------------------------------------------------------------------------
+
+func BenchmarkGetResultRow(b *testing.B) {
+	for _, r := range []uint{1, 7, 8} {
+		name := fmt.Sprintf("r=%d", r)
+		b.Run(name, func(b *testing.B) {
+			h := newStandardHasher(128, 10000, r, true)
+			h.setOrdinalSeed(0)
+			hashes := precomputedHashes(h, 4096)
+			mask := len(hashes) - 1
+
+			rehashed := make([]uint64, len(hashes))
+			for i, kh := range hashes {
+				rehashed[i] = h.rehash(kh)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink uint8
+			for i := 0; i < b.N; i++ {
+				sink = h.getResultRow(rehashed[i&mask])
+			}
+			_ = sink
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. keyHash (Phase 1) — XXH3, for reference baseline
+//
+// Phase 1 cost: XXH3_64bits over the raw key bytes. Called once per key
+// (amortised across all seed attempts).
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Key size   ns/op    MB/s       allocs/op
+//   ────────   ─────    ────────   ─────────
+//   8 B        2.33     3,438      0
+//   32 B       3.24     9,888      0
+//   128 B      8.36     15,313     0
+//   1024 B     49.66    20,622     0
+//
+// Key observations:
+//   • For typical filter keys (8–32 B), keyHash is now the dominant cost
+//     (~6× more expensive than derive at 0.39 ns).
+//   • XXH3 saturates memory bandwidth around 20 GB/s for large keys.
+//   • Total per-key cost (Phase 1 + Phase 2) ≈ 2.7 ns for 8 B keys.
+// ---------------------------------------------------------------------------
+
+func BenchmarkKeyHash(b *testing.B) {
+	for _, size := range []int{8, 32, 128, 1024} {
+		name := fmt.Sprintf("keySize=%d", size)
+		b.Run(name, func(b *testing.B) {
+			h := newStandardHasher(128, 10000, 7, true)
+			key := make([]byte, size)
+			for i := range key {
+				key[i] = byte(i)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			var sink uint64
+			for i := 0; i < b.N; i++ {
+				sink = h.keyHash(key)
+			}
+			_ = sink
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. Throughput — derive() in a realistic batch loop
+//
+// Simulates a full seed-attempt pass over 100K pre-hashed keys.
+// Reports wall-clock time per pass and throughput in keys/op.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   ns/op     keys/op   ~keys/sec     allocs/op
+//   ─────   ───────   ───────   ──────────    ─────────
+//   w=64    39,142    100,000   ~2.56B        0
+//   w=128   38,730    100,000   ~2.58B        0
+//
+// Key observations:
+//   • ~0.39 ns/key in a tight loop — matches per-call BenchmarkDerive.
+//   • ~2.5 billion keys/sec means a 1M-key filter's Phase 2 takes ~0.39 ms
+//     per seed attempt.
+//   • 7× faster than pre-optimisation baseline (~271 µs → ~39 µs).
+//   • w=64 and w=128 are indistinguishable at batch scale.
+// ---------------------------------------------------------------------------
+
+func BenchmarkDeriveThroughput(b *testing.B) {
+	// Simulates a full seed-attempt pass over N keys.
+	// Reports throughput in keys/sec.
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 100_000
+			h := newStandardHasher(w, numKeys, 7, true)
+			h.setOrdinalSeed(0)
+			hashes := precomputedHashes(h, numKeys)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink hashResult
+			for i := 0; i < b.N; i++ {
+				for _, kh := range hashes {
+					sink = h.derive(kh)
+				}
+			}
+			_ = sink
+			b.ReportMetric(float64(numKeys), "keys/op")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. Seed conversion — ordinalSeedToRaw / rawSeedToOrdinal
+//
+// Bijective mixing between small ordinal seeds and 64-bit raw seeds.
+// Called once per seed attempt (not per key), so not on the hot path.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Direction        ns/op   allocs/op
+//   ─────────        ─────   ─────────
+//   ordinalToRaw     0.39    0
+//   rawToOrdinal     0.39    0
+//
+// Key observation: multiply + XOR — sub-nanosecond, negligible.
+// ---------------------------------------------------------------------------
+
+func BenchmarkSeedConversion(b *testing.B) {
+	b.Run("ordinalToRaw", func(b *testing.B) {
+		var sink uint64
+		for i := 0; i < b.N; i++ {
+			sink = ordinalSeedToRaw(uint32(i))
+		}
+		_ = sink
+	})
+	b.Run("rawToOrdinal", func(b *testing.B) {
+		var sink uint32
+		for i := 0; i < b.N; i++ {
+			sink = rawSeedToOrdinal(uint64(i))
+		}
+		_ = sink
+	})
+}

--- a/hash_test.go
+++ b/hash_test.go
@@ -1,0 +1,505 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+// helper: creates a standardHasher with common test defaults.
+// w=128, numSlots=13000, resultBits=7 (~1% FPR).
+func newTestHasher() *standardHasher {
+	var coeffBits uint32 = 128
+	numSlots := uint32(13000)
+	numStarts := numSlots - coeffBits + 1 // 12873
+	return newStandardHasher(coeffBits, numStarts, 7, true)
+}
+
+func TestKeyHash(t *testing.T) {
+	h := newTestHasher()
+
+	// Basic sanity: same key always produces same hash
+	h1 := h.keyHash([]byte("hello"))
+	h2 := h.keyHash([]byte("hello"))
+	if h1 != h2 {
+		t.Errorf("same key produced different hashes: %x vs %x", h1, h2)
+	}
+
+	// Different keys produce different hashes
+	h3 := h.keyHash([]byte("world"))
+	if h1 == h3 {
+		t.Errorf("different keys produced same hash: %x", h1)
+	}
+
+	t.Logf("keyHash(\"hello\") = 0x%016x", h1)
+	t.Logf("keyHash(\"world\") = 0x%016x", h3)
+}
+
+func TestSeedConversion(t *testing.T) {
+	// Ordinal → Raw → Ordinal round-trip
+	for _, ordinal := range []uint32{0, 1, 2, 42, 127, 255} {
+		raw := ordinalSeedToRaw(ordinal)
+		back := rawSeedToOrdinal(raw)
+		if back != ordinal {
+			t.Errorf("round-trip failed for ordinal %d: raw=%x, back=%d", ordinal, raw, back)
+		}
+	}
+
+	// Sequential ordinal seeds produce very different raw seeds
+	raw0 := ordinalSeedToRaw(0)
+	raw1 := ordinalSeedToRaw(1)
+	raw2 := ordinalSeedToRaw(2)
+	t.Logf("ordinal 0 → raw 0x%016x", raw0)
+	t.Logf("ordinal 1 → raw 0x%016x", raw1)
+	t.Logf("ordinal 2 → raw 0x%016x", raw2)
+
+	// They should differ in many bits
+	diff := raw0 ^ raw1
+	if diff == 0 {
+		t.Error("ordinal 0 and 1 produced identical raw seeds")
+	}
+}
+
+func TestSetGetOrdinalSeed(t *testing.T) {
+	h := newTestHasher()
+
+	for _, ordinal := range []uint32{0, 1, 42, 127, 255} {
+		h.setOrdinalSeed(ordinal)
+		got := h.getOrdinalSeed()
+		if got != ordinal {
+			t.Errorf("setOrdinalSeed(%d) → getOrdinalSeed() = %d", ordinal, got)
+		}
+	}
+}
+
+func TestSetGetNumStarts(t *testing.T) {
+	h := newStandardHasher(128, 100, 7, true)
+	if h.getNumStarts() != 100 {
+		t.Errorf("expected numStarts=100, got %d", h.getNumStarts())
+	}
+
+	h.setNumStarts(5000)
+	if h.getNumStarts() != 5000 {
+		t.Errorf("expected numStarts=5000, got %d", h.getNumStarts())
+	}
+}
+
+func TestGetCoeffBits(t *testing.T) {
+	for _, w := range []uint32{32, 64, 128} {
+		h := newStandardHasher(w, 100, 7, true)
+		if h.getCoeffBits() != w {
+			t.Errorf("expected coeffBits=%d, got %d", w, h.getCoeffBits())
+		}
+	}
+}
+
+func TestGetResultBits(t *testing.T) {
+	h := newStandardHasher(128, 100, 7, true)
+	if h.getResultBits() != 7 {
+		t.Errorf("expected resultBits=7, got %d", h.getResultBits())
+	}
+}
+
+func TestNewStandardHasher_InvalidCoeffBits(t *testing.T) {
+	for _, w := range []uint32{0, 16, 48, 96, 256} {
+		w := w
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("newStandardHasher(%d, ...) should panic", w)
+				}
+			}()
+			newStandardHasher(w, 100, 7, true)
+		})
+	}
+}
+
+func TestRehash(t *testing.T) {
+	h := newTestHasher()
+	kh := h.keyHash([]byte("test_key"))
+
+	// Same hash + same seed = same result
+	h.setOrdinalSeed(0)
+	r1 := h.rehash(kh)
+	r2 := h.rehash(kh)
+	if r1 != r2 {
+		t.Errorf("rehash not deterministic")
+	}
+
+	// Different seeds produce different results
+	h.setOrdinalSeed(1)
+	r3 := h.rehash(kh)
+	if r1 == r3 {
+		t.Errorf("different seeds produced same rehash")
+	}
+
+	t.Logf("rehash(h, seed=0) = 0x%016x", r1)
+	t.Logf("rehash(h, seed=1) = 0x%016x", r3)
+}
+
+func TestFastRange64(t *testing.T) {
+	h := newTestHasher()
+
+	// Output must be in [0, range)
+	for _, rangeVal := range []uint32{1, 10, 100, 1000, 10000, 100000} {
+		for i := uint64(0); i < 1000; i++ {
+			kh := h.keyHash([]byte(fmt.Sprintf("key_%d", i)))
+			result := fastRange64(kh, rangeVal)
+			if result >= rangeVal {
+				t.Errorf("fastRange64(0x%x, %d) = %d, out of range", kh, rangeVal, result)
+			}
+		}
+	}
+}
+
+func TestGetStart(t *testing.T) {
+	h := newTestHasher()
+	h.setOrdinalSeed(0)
+
+	kh := h.keyHash([]byte("my_key"))
+	rh := h.rehash(kh)
+	start := h.getStart(rh)
+
+	numStarts := h.getNumStarts()
+	if start >= numStarts {
+		t.Errorf("start %d >= numStarts %d", start, numStarts)
+	}
+
+	t.Logf("numStarts=%d, start=%d", numStarts, start)
+}
+
+func TestGetCoeffRow(t *testing.T) {
+	h := newTestHasher()
+	h.setOrdinalSeed(0)
+
+	kh := h.keyHash([]byte("my_key"))
+	rh := h.rehash(kh)
+	cr := h.getCoeffRow(rh)
+
+	// Must have bit 0 set (firstCoeffAlwaysOne)
+	if cr.lo&1 == 0 {
+		t.Error("coeffRow bit 0 is not set (firstCoeffAlwaysOne violated)")
+	}
+
+	// Must be non-zero
+	if cr.isZero() {
+		t.Error("coeffRow is zero")
+	}
+
+	t.Logf("coeffRow = {hi: 0x%016x, lo: 0x%016x}", cr.hi, cr.lo)
+}
+
+func TestGetResultRow(t *testing.T) {
+	h7 := newStandardHasher(128, 12873, 7, true)
+	h1 := newStandardHasher(128, 12873, 1, true)
+	h8 := newStandardHasher(128, 12873, 8, true)
+
+	h7.setOrdinalSeed(0)
+	h1.setOrdinalSeed(0)
+	h8.setOrdinalSeed(0)
+
+	kh := h7.keyHash([]byte("my_key"))
+	rh := h7.rehash(kh)
+
+	// r=7 → result must be in [0, 128)
+	rr7 := h7.getResultRow(rh)
+	if rr7 >= 128 {
+		t.Errorf("resultRow with 7 bits = %d, expected < 128", rr7)
+	}
+
+	// r=1 → result must be 0 or 1
+	rh1 := h1.rehash(kh) // same raw seed (ordinal=0)
+	rr1 := h1.getResultRow(rh1)
+	if rr1 > 1 {
+		t.Errorf("resultRow with 1 bit = %d, expected 0 or 1", rr1)
+	}
+
+	// r=8 → full byte
+	rh8 := h8.rehash(kh)
+	rr8 := h8.getResultRow(rh8)
+
+	t.Logf("resultRow(r=1)=%d, (r=7)=%d, (r=8)=%d", rr1, rr7, rr8)
+}
+
+func TestDerive_Determinism(t *testing.T) {
+	h := newTestHasher()
+	h.setOrdinalSeed(42)
+
+	key := []byte("determinism_test")
+	kh := h.keyHash(key)
+
+	r1 := h.derive(kh)
+	r2 := h.derive(kh)
+
+	if r1.start != r2.start || r1.coeffRow != r2.coeffRow || r1.result != r2.result {
+		t.Error("derive not deterministic")
+	}
+
+	t.Logf("start=%d, coeffRow={0x%016x, 0x%016x}, result=%d",
+		r1.start, r1.coeffRow.hi, r1.coeffRow.lo, r1.result)
+}
+
+func TestDerive_SeedIndependence(t *testing.T) {
+	h := newTestHasher()
+
+	key := []byte("independence_test")
+	kh := h.keyHash(key)
+
+	h.setOrdinalSeed(0)
+	r0 := h.derive(kh)
+
+	h.setOrdinalSeed(1)
+	r1 := h.derive(kh)
+
+	// With different seeds, at least one of start/coeff/result should differ
+	if r0.start == r1.start && r0.coeffRow == r1.coeffRow && r0.result == r1.result {
+		t.Error("different seeds produced identical hashResult — very unlikely")
+	}
+
+	t.Logf("seed=0: start=%d, result=%d", r0.start, r0.result)
+	t.Logf("seed=1: start=%d, result=%d", r1.start, r1.result)
+}
+
+func TestDerive_MatchesStandaloneFunctions(t *testing.T) {
+	// Verify that the hand-inlined derive() produces exactly the same
+	// (start, coeffRow, result) as calling rehash → getStart/getCoeffRow/
+	// getResultRow individually. This catches any divergence introduced
+	// by the inlining optimisations (fused multiply, branchless masks,
+	// omitted zero-guard).
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				h := newStandardHasher(w, 10000, 7, fcao)
+
+				for seed := uint32(0); seed < 3; seed++ {
+					h.setOrdinalSeed(seed)
+
+					for i := 0; i < 10000; i++ {
+						kh := h.keyHash([]byte(fmt.Sprintf("key_%d", i)))
+
+						// Optimised path
+						got := h.derive(kh)
+
+						// Standalone path
+						rh := h.rehash(kh)
+						wantStart := h.getStart(rh)
+						wantCoeff := h.getCoeffRow(rh)
+						wantResult := h.getResultRow(rh)
+
+						if got.start != wantStart {
+							t.Fatalf("seed=%d key_%d: start mismatch: derive=%d standalone=%d",
+								seed, i, got.start, wantStart)
+						}
+						if got.result != wantResult {
+							t.Fatalf("seed=%d key_%d: result mismatch: derive=%d standalone=%d",
+								seed, i, got.result, wantResult)
+						}
+						// coeffRow: derive() omits the zero-guard, so for the
+						// astronomically rare case where the branchless path
+						// produces zero (P≈2^-w), getCoeffRow forces it to 1
+						// but derive() does not. We accept this known divergence.
+						if got.coeffRow != wantCoeff && !got.coeffRow.isZero() {
+							t.Fatalf("seed=%d key_%d: coeffRow mismatch: derive={0x%x,0x%x} standalone={0x%x,0x%x}",
+								seed, i, got.coeffRow.hi, got.coeffRow.lo, wantCoeff.hi, wantCoeff.lo)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestHasherInterface(t *testing.T) {
+	// Verify that standardHasher satisfies the hasher interface at runtime.
+	var h hasher = newStandardHasher(128, 12873, 7, true)
+
+	h.setOrdinalSeed(0)
+	kh := h.keyHash([]byte("interface_test"))
+	hr := h.derive(kh)
+
+	if hr.start >= h.getNumStarts() {
+		t.Errorf("start %d >= numStarts %d", hr.start, h.getNumStarts())
+	}
+	if hr.coeffRow.lo&1 == 0 {
+		t.Error("coeffRow LSB not set through interface")
+	}
+	if hr.result >= (1 << h.getResultBits()) {
+		t.Errorf("result %d exceeds %d-bit range", hr.result, h.getResultBits())
+	}
+	if h.getCoeffBits() != 128 {
+		t.Errorf("expected coeffBits=128 via interface, got %d", h.getCoeffBits())
+	}
+	if !h.firstCoeffAlwaysOne() {
+		t.Error("expected firstCoeffAlwaysOne=true via interface")
+	}
+
+	t.Logf("via interface: start=%d, result=%d", hr.start, hr.result)
+}
+
+func TestStartDistribution(t *testing.T) {
+	// Check that starts are roughly uniformly distributed.
+	numStarts := uint32(10000)
+	h := newStandardHasher(128, numStarts, 7, true)
+	h.setOrdinalSeed(0)
+
+	numKeys := 100000
+	buckets := make([]int, 10) // 10 buckets across the range
+
+	for i := 0; i < numKeys; i++ {
+		kh := h.keyHash([]byte(fmt.Sprintf("distribution_key_%d", i)))
+		rh := h.rehash(kh)
+		start := h.getStart(rh)
+		bucket := int(start) * 10 / int(numStarts)
+		if bucket >= 10 {
+			bucket = 9
+		}
+		buckets[bucket]++
+	}
+
+	expected := numKeys / 10
+	for i, count := range buckets {
+		ratio := float64(count) / float64(expected)
+		if ratio < 0.85 || ratio > 1.15 {
+			t.Errorf("bucket %d: count=%d, expected ~%d (ratio=%.2f)", i, count, expected, ratio)
+		}
+		t.Logf("bucket %d: %d (%.1f%%)", i, count, 100*ratio)
+	}
+}
+
+func TestGetCoeffRow_AllWidths(t *testing.T) {
+	// Verify getCoeffRow respects the configured ribbon width w.
+	// For each w, the coefficient row must:
+	//   1. Have bit 0 set (firstCoeffAlwaysOne)
+	//   2. Have all bits above w be zero
+	//   3. Be non-zero
+	for _, w := range []uint32{32, 64, 128} {
+		w := w
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			h := newStandardHasher(w, 10000, 7, true)
+			h.setOrdinalSeed(0)
+
+			for i := 0; i < 10000; i++ {
+				kh := h.keyHash([]byte(fmt.Sprintf("key_%d", i)))
+				rh := h.rehash(kh)
+				cr := h.getCoeffRow(rh)
+
+				// Bit 0 must be set
+				if cr.lo&1 == 0 {
+					t.Fatalf("key_%d: coeffRow LSB not set for w=%d", i, w)
+				}
+
+				// Must be non-zero
+				if cr.isZero() {
+					t.Fatalf("key_%d: coeffRow is zero for w=%d", i, w)
+				}
+
+				// Bits above w must be zero
+				switch w {
+				case 32:
+					if cr.hi != 0 || cr.lo>>32 != 0 {
+						t.Fatalf("key_%d: w=32 but bits above 32 set: {hi: 0x%x, lo: 0x%x}", i, cr.hi, cr.lo)
+					}
+				case 64:
+					if cr.hi != 0 {
+						t.Fatalf("key_%d: w=64 but hi bits set: 0x%x", i, cr.hi)
+					}
+				case 128:
+					// All 128 bits available, no constraint on upper bits
+				}
+			}
+		})
+	}
+}
+
+func TestGetCoeffRow_WidthsProduceDifferentRows(t *testing.T) {
+	// Different widths should generally produce different coefficient rows
+	// for the same input hash, since the derivation logic differs.
+	h32 := newStandardHasher(32, 10000, 7, true)
+	h64 := newStandardHasher(64, 10000, 7, true)
+	h128 := newStandardHasher(128, 10000, 7, true)
+
+	h32.setOrdinalSeed(0)
+	h64.setOrdinalSeed(0)
+	h128.setOrdinalSeed(0)
+
+	kh := h32.keyHash([]byte("width_test"))
+	rh := h32.rehash(kh)
+
+	cr32 := h32.getCoeffRow(rh)
+	cr64 := h64.getCoeffRow(rh)
+	cr128 := h128.getCoeffRow(rh)
+
+	t.Logf("w=32:  {hi: 0x%016x, lo: 0x%016x}", cr32.hi, cr32.lo)
+	t.Logf("w=64:  {hi: 0x%016x, lo: 0x%016x}", cr64.hi, cr64.lo)
+	t.Logf("w=128: {hi: 0x%016x, lo: 0x%016x}", cr128.hi, cr128.lo)
+
+	// w=32 should have fewer bits set than w=64/128
+	if cr32.hi != 0 {
+		t.Error("w=32 should have hi=0")
+	}
+	if cr64.hi != 0 {
+		t.Error("w=64 should have hi=0")
+	}
+	if cr128.hi == 0 {
+		t.Error("w=128 should have hi≠0 for most inputs")
+	}
+}
+
+func TestFirstCoeffAlwaysOne(t *testing.T) {
+	hTrue := newStandardHasher(128, 10000, 7, true)
+	if !hTrue.firstCoeffAlwaysOne() {
+		t.Error("expected firstCoeffAlwaysOne=true")
+	}
+
+	hFalse := newStandardHasher(128, 10000, 7, false)
+	if hFalse.firstCoeffAlwaysOne() {
+		t.Error("expected firstCoeffAlwaysOne=false")
+	}
+}
+
+func TestGetCoeffRow_NoFirstCoeffAlwaysOne(t *testing.T) {
+	// When firstCoeffAlwaysOne=false, LSB is NOT forced to 1.
+	// coeffRow must still be non-zero (or near-zero probability for w=32).
+	for _, w := range []uint32{32, 64, 128} {
+		w := w
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			h := newStandardHasher(w, 10000, 7, false)
+			h.setOrdinalSeed(0)
+
+			lsbZeroCount := 0
+			for i := 0; i < 10000; i++ {
+				kh := h.keyHash([]byte(fmt.Sprintf("key_%d", i)))
+				rh := h.rehash(kh)
+				cr := h.getCoeffRow(rh)
+
+				// Must be non-zero
+				if cr.isZero() {
+					t.Fatalf("key_%d: coeffRow is zero for w=%d", i, w)
+				}
+
+				// Bits above w must still be zero
+				switch w {
+				case 32:
+					if cr.hi != 0 || cr.lo>>32 != 0 {
+						t.Fatalf("key_%d: w=32 but bits above 32 set", i)
+					}
+				case 64:
+					if cr.hi != 0 {
+						t.Fatalf("key_%d: w=64 but hi bits set", i)
+					}
+				}
+
+				if cr.lo&1 == 0 {
+					lsbZeroCount++
+				}
+			}
+
+			// With firstCoeffAlwaysOne=false, roughly half should have LSB=0
+			if lsbZeroCount == 0 {
+				t.Errorf("w=%d: all 10000 rows had LSB=1, expected ~50%% with LSB=0", w)
+			}
+			t.Logf("w=%d: %d/10000 rows had LSB=0 (%.1f%%)", w, lsbZeroCount,
+				100*float64(lsbZeroCount)/10000)
+		})
+	}
+}

--- a/uint128.go
+++ b/uint128.go
@@ -1,0 +1,113 @@
+package ribbon
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+// =============================================================================
+// uint128 — 128-bit unsigned integer for coefficient rows
+// =============================================================================
+
+// uint128 represents a 128-bit unsigned integer.
+// Used as the coefficient row type when ribbon width w=128.
+// Paper §4: "r=128 seems to be closest to a generally good choice for Ribbon"
+// because it scales to ~10M keys with only ~5% space overhead.
+// hi holds the upper 64 bits, lo holds the lower 64 bits.
+type uint128 struct {
+	hi uint64
+	lo uint64
+}
+
+// isZero returns true if the 128-bit value is zero.
+func (u uint128) isZero() bool {
+	return u.hi == 0 && u.lo == 0
+}
+
+// xor returns u XOR v.
+func (u uint128) xor(v uint128) uint128 {
+	return uint128{hi: u.hi ^ v.hi, lo: u.lo ^ v.lo}
+}
+
+// and returns u AND v.
+func (u uint128) and(v uint128) uint128 {
+	return uint128{hi: u.hi & v.hi, lo: u.lo & v.lo}
+}
+
+// or returns u OR v.
+func (u uint128) or(v uint128) uint128 {
+	return uint128{hi: u.hi | v.hi, lo: u.lo | v.lo}
+}
+
+// lsh returns u << n (n must be 0..127).
+func (u uint128) lsh(n uint) uint128 {
+	if n >= 128 {
+		return uint128{}
+	}
+	if n >= 64 {
+		return uint128{hi: u.lo << (n - 64), lo: 0}
+	}
+	if n == 0 {
+		return u
+	}
+	return uint128{
+		hi: (u.hi << n) | (u.lo >> (64 - n)),
+		lo: u.lo << n,
+	}
+}
+
+// rsh returns u >> n (n must be 0..127).
+func (u uint128) rsh(n uint) uint128 {
+	if n >= 128 {
+		return uint128{}
+	}
+	if n >= 64 {
+		return uint128{hi: 0, lo: u.hi >> (n - 64)}
+	}
+	if n == 0 {
+		return u
+	}
+	return uint128{
+		hi: u.hi >> n,
+		lo: (u.lo >> n) | (u.hi << (64 - n)),
+	}
+}
+
+// bitParity returns 1 if the number of set bits is odd, 0 if even.
+// Used during query to XOR selected solution rows.
+func (u uint128) bitParity() byte {
+	x := u.hi ^ u.lo
+	return byte(bits.OnesCount64(x) & 1)
+}
+
+// bit returns the value of the i-th bit (0 = LSB of lo, 127 = MSB of hi).
+func (u uint128) bit(i uint) uint {
+	if i >= 128 {
+		return 0
+	}
+	if i >= 64 {
+		return uint((u.hi >> (i - 64)) & 1)
+	}
+	return uint((u.lo >> i) & 1)
+}
+
+// putBytes serialises the uint128 into a 16-byte array in little-endian order.
+// lo occupies bytes [0..7], hi occupies bytes [8..15].
+func (u uint128) putBytes() [16]byte {
+	var b [16]byte
+	binary.LittleEndian.PutUint64(b[0:8], u.lo)
+	binary.LittleEndian.PutUint64(b[8:16], u.hi)
+	return b
+}
+
+// uint128FromBytes reads a uint128 from a 16-byte slice in little-endian order.
+// Panics if len(b) < 16.
+func uint128FromBytes(b []byte) uint128 {
+	if len(b) < 16 {
+		panic("uint128FromBytes: source slice must be at least 16 bytes")
+	}
+	return uint128{
+		lo: binary.LittleEndian.Uint64(b[0:8]),
+		hi: binary.LittleEndian.Uint64(b[8:16]),
+	}
+}

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -1,0 +1,166 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUint128_BasicOps(t *testing.T) {
+	a := uint128{hi: 0xFF, lo: 0x01}
+	b := uint128{hi: 0x0F, lo: 0x10}
+
+	// XOR
+	x := a.xor(b)
+	if x.hi != 0xF0 || x.lo != 0x11 {
+		t.Errorf("XOR wrong: %+v", x)
+	}
+
+	// AND
+	n := a.and(b)
+	if n.hi != 0x0F || n.lo != 0x00 {
+		t.Errorf("AND wrong: %+v", n)
+	}
+
+	// OR
+	o := a.or(b)
+	if o.hi != 0xFF || o.lo != 0x11 {
+		t.Errorf("OR wrong: %+v", o)
+	}
+}
+
+func TestUint128_Shifts(t *testing.T) {
+	// Test left shift across 64-bit boundary
+	a := uint128{hi: 0, lo: 1}
+	shifted := a.lsh(64)
+	if shifted.hi != 1 || shifted.lo != 0 {
+		t.Errorf("lsh(64) wrong: %+v", shifted)
+	}
+
+	// Test right shift across 64-bit boundary
+	b := uint128{hi: 1, lo: 0}
+	shifted = b.rsh(64)
+	if shifted.hi != 0 || shifted.lo != 1 {
+		t.Errorf("rsh(64) wrong: %+v", shifted)
+	}
+
+	// Small shifts
+	c := uint128{hi: 0, lo: 0x8000000000000000}
+	shifted = c.lsh(1)
+	if shifted.hi != 1 || shifted.lo != 0 {
+		t.Errorf("lsh(1) carry wrong: %+v", shifted)
+	}
+}
+
+func TestUint128_BitParity(t *testing.T) {
+	// Even number of bits → parity 0
+	a := uint128{hi: 0, lo: 0x3} // bits: 11 → 2 bits → even
+	if a.bitParity() != 0 {
+		t.Errorf("expected parity 0 for 0x3, got %d", a.bitParity())
+	}
+
+	// Odd number of bits → parity 1
+	b := uint128{hi: 0, lo: 0x7} // bits: 111 → 3 bits → odd
+	if b.bitParity() != 1 {
+		t.Errorf("expected parity 1 for 0x7, got %d", b.bitParity())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// uint128 serialization: putBytes / uint128FromBytes
+// ---------------------------------------------------------------------------
+
+func TestUint128_PutBytesFromBytes_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		val  uint128
+	}{
+		{"zero", uint128{hi: 0, lo: 0}},
+		{"lo_only", uint128{hi: 0, lo: 0xDEADBEEFCAFEBABE}},
+		{"hi_only", uint128{hi: 0x0123456789ABCDEF, lo: 0}},
+		{"both", uint128{hi: 0x0123456789ABCDEF, lo: 0xDEADBEEFCAFEBABE}},
+		{"max", uint128{hi: 0xFFFFFFFFFFFFFFFF, lo: 0xFFFFFFFFFFFFFFFF}},
+		{"one", uint128{hi: 0, lo: 1}},
+		{"hi_msb", uint128{hi: 0x8000000000000000, lo: 0}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := tc.val.putBytes()
+			got := uint128FromBytes(buf[:])
+			if got != tc.val {
+				t.Errorf("round-trip failed: put %+v, got back %+v", tc.val, got)
+			}
+		})
+	}
+}
+
+func TestUint128_PutBytes_KnownPattern(t *testing.T) {
+	// Verify exact byte layout: lo in bytes [0..7], hi in bytes [8..15],
+	// each in little-endian.
+	v := uint128{hi: 0x0807060504030201, lo: 0x100F0E0D0C0B0A09}
+	buf := v.putBytes()
+
+	// lo = 0x100F0E0D0C0B0A09 little-endian → 09 0A 0B 0C 0D 0E 0F 10
+	expectedLo := []byte{0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
+	// hi = 0x0807060504030201 little-endian → 01 02 03 04 05 06 07 08
+	expectedHi := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	for i := 0; i < 8; i++ {
+		if buf[i] != expectedLo[i] {
+			t.Errorf("byte[%d] = 0x%02X, want 0x%02X (lo region)", i, buf[i], expectedLo[i])
+		}
+	}
+	for i := 0; i < 8; i++ {
+		if buf[8+i] != expectedHi[i] {
+			t.Errorf("byte[%d] = 0x%02X, want 0x%02X (hi region)", 8+i, buf[8+i], expectedHi[i])
+		}
+	}
+}
+
+func TestUint128_FromBytes_KnownPattern(t *testing.T) {
+	// The 16 bytes 0x01..0x10 should decode as:
+	// lo = LittleEndian(01 02 03 04 05 06 07 08) = 0x0807060504030201
+	// hi = LittleEndian(09 0A 0B 0C 0D 0E 0F 10) = 0x100F0E0D0C0B0A09
+	buf := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
+	got := uint128FromBytes(buf)
+	wantLo := uint64(0x0807060504030201)
+	wantHi := uint64(0x100F0E0D0C0B0A09)
+	if got.lo != wantLo || got.hi != wantHi {
+		t.Errorf("got {hi: 0x%016X, lo: 0x%016X}, want {hi: 0x%016X, lo: 0x%016X}",
+			got.hi, got.lo, wantHi, wantLo)
+	}
+}
+
+func TestUint128_PutBytes_ReturnsSizeExactly16(t *testing.T) {
+	v := uint128{hi: 0xAAAAAAAAAAAAAAAA, lo: 0xBBBBBBBBBBBBBBBB}
+	buf := v.putBytes()
+	if len(buf) != 16 {
+		t.Fatalf("expected 16 bytes, got %d", len(buf))
+	}
+	got := uint128FromBytes(buf[:])
+	if got != v {
+		t.Errorf("got %+v, want %+v", got, v)
+	}
+}
+
+func TestUint128_FromBytes_PanicOnShortSlice(t *testing.T) {
+	shortLens := []int{0, 1, 8, 15}
+
+	for _, length := range shortLens {
+		t.Run(fmt.Sprintf("len=%d", length), func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("uint128FromBytes did not panic for len=%d", length)
+				}
+				msg, ok := r.(string)
+				if !ok || msg != "uint128FromBytes: source slice must be at least 16 bytes" {
+					t.Fatalf("unexpected panic: %v", r)
+				}
+			}()
+			buf := make([]byte, length)
+			uint128FromBytes(buf)
+		})
+	}
+}


### PR DESCRIPTION
## Hash Pipeline for Ribbon Filter

First PR of the **ribbonGo** library — a research-friendly, from-scratch Go implementation of the [Ribbon Filter](https://arxiv.org/abs/2103.02515) (Dillinger & Walzer, 2021).

This PR implements the **complete two-phase hash pipeline** that maps keys to `(start, coeffRow, result)` triples for the banding linear system.

### What is a Ribbon Filter?

A Ribbon filter (**R**apid **I**ncremental **B**oolean **B**anding **ON** the fly) is a compact static filter that encodes keys into a linear system over GF(2). Compared to Bloom filters, Ribbon achieves ~30% less space at the same false-positive rate, with competitive query speed.

### What's in this PR

| File | Lines | Purpose |
|------|-------|---------|
| `uint128.go` | 113 | 128-bit unsigned integer type (XOR, AND, OR, shifts, bit parity, serialization) |
| `hash.go` | 489 | `hasher` interface + `standardHasher` — full hash pipeline with CPU-level optimizations |
| `uint128_test.go` | 166 | 8 test functions for uint128 ops and serialization |
| `hash_test.go` | 505 | 21 test functions covering all hash pipeline components |
| `hash_bench_test.go` | 373 | 8 benchmark functions with reference result tables |

### Hash Pipeline Design

```
Phase 1 (once per key):     Key → XXH3_64bits(key) → stored uint64 hash
Phase 2 (per seed attempt): stored hash → rehash → (start, coeffRow, result)
  ├─ start:    fastRange64(rehashed, numStarts)      [high bits]
  ├─ coeffRow: multiply → expand/truncate to w bits   [low/middle bits]
  └─ result:   multiply → bswap64 → mask to r bits    [byte-swapped]
```

**Configurable parameters** (all paper-described options exposed, not just RocksDB production defaults):
- **Ribbon width `w`**: 32, 64, or 128 — controls overhead ratio `m/n ≈ 1 + 2.3/w`
- **Result bits `r`**: 1–8 — controls FPR ≈ `2^(−r)`
- **`firstCoeffAlwaysOne`**: `true`/`false` — when true, forces LSB=1 for faster banding pivots

### CPU-Level Optimizations

The `derive()` function is the innermost call in both banding construction and seed retry. Four progressive optimizations brought it under the Go compiler's inlining budget:

| Optimization | Inlining Cost | Technique |
|---|---|---|
| Baseline (sub-method calls) | 149 ❌ | — |
| Fused multiply (coeff + result share one `h × factor`) | 104 ❌ | Eliminated redundant multiply |
| Pre-computed masks replace `switch` on width | 85 ❌ | `coeffLoMask`, `coeffHiMask`, `coeffXor` |
| Branchless `coeffOrMask` replaces `if forceFirstCoeff` | **67 ✅** | Single OR operation |

**Result: `derive()` is fully inlineable and branchless.**

### Benchmark Results (Apple M3 Pro, Go 1.25)

```
BenchmarkDerive (all widths, all fcao):   ~0.39 ns/op   0 allocs
BenchmarkDeriveThroughput (100K keys):    ~2.5 billion keys/sec
BenchmarkKeyHash (8B key, XXH3):          ~2.3 ns/op    0 allocs
```

- `derive()` at 0.39 ns/op means Phase 2 is no longer the bottleneck — Phase 1 (XXH3) dominates at ~6× the cost
- A 1M-key filter's Phase 2 completes in ~0.39 ms per seed attempt

### Test Coverage

57 test cases across 29 top-level test functions covering:
- Determinism, seed independence, cross-width consistency
- **`derive()` vs standalone functions cross-validation** — 180,000 comparisons across all 6 configurations (w × fcao)
- Start position uniformity (chi-squared-style bucket test over 100K keys)
- `firstCoeffAlwaysOne` enforcement and LSB distribution when disabled
- uint128 arithmetic, shift boundary cases, serialization round-trips

### What's Next

This hash pipeline feeds into the next PRs:
1. **Banding** — incremental Gaussian elimination (the core construction algorithm)
2. **Back-substitution** — solving the linear system to produce the solution matrix
3. **Query** — membership testing against the solution
4. **Filter API** — public `Build()` / `MayContain()` interface
