### PR TITLE
Core Banding Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode
 /vendor
+/.github

--- a/bander.go
+++ b/bander.go
@@ -1,0 +1,751 @@
+package ribbon
+
+import "math/bits"
+
+// =============================================================================
+// BANDING SLOT — logical per-row view for the upper-triangular banded matrix
+// =============================================================================
+
+// bandingSlot is the logical view of one row in the upper-triangular banded
+// matrix produced by Gaussian elimination over GF(2).
+//
+// Paper §2: the banding step constructs an upper-triangular matrix where
+// row j has its pivot (leading 1) at column j. The coefficient row stored
+// here is right-shifted so that bit 0 is always the pivot bit. The
+// remaining bits represent the equation's dependencies on columns j+1,
+// j+2, …, up to the ribbon width w.
+//
+// This type is used by the back-substitution layer to read out the final
+// matrix via getSlot(). Internally, the bander stores the data in a
+// Struct-of-Arrays (SoA) layout for better cache utilisation — see
+// standardBander documentation for the rationale.
+//
+// Occupancy tracking: a slot is occupied iff coeffRow is non-zero.
+// This eliminates the need for a separate boolean array or bitset,
+// improving cache locality by avoiding an extra memory access per slot
+// probe. The invariant holds because:
+//
+//	(a) the hasher guarantees non-zero coefficient rows (paper §2),
+//	(b) during elimination, a zero coefficient means linear dependence —
+//	    the insertion fails immediately and nothing is stored,
+//	(c) after right-shifting to the pivot, bit 0 is always 1 for any
+//	    stored coefficient row.
+type bandingSlot struct {
+	coeffRow uint128 // right-shifted coefficient row; bit 0 = pivot. Zero iff empty.
+	result   uint8   // r-bit fingerprint for this row's equation.
+}
+
+// =============================================================================
+// BANDER INTERFACE
+// =============================================================================
+
+// bander defines the interface for Ribbon filter matrix construction
+// (the "banding" step).
+//
+// Paper §2: the banding step takes N (start, coefficient, result) triples
+// and performs on-the-fly Gaussian elimination over GF(2) to produce an
+// upper-triangular banded matrix. The matrix has m slots (= numSlots),
+// and each key's non-zero coefficients span a narrow "ribbon" of width w
+// starting at its assigned start slot s.
+//
+// The linear system being solved is:
+//
+//	For each key x:  C[x] · S[s(x) … s(x)+w-1] = r(x)   (mod 2)
+//
+// where C[x] is the w-bit coefficient row, S is the solution vector
+// (computed later by back-substitution), and r(x) is the result row.
+//
+// Construction succeeds when all N keys are inserted without linear
+// dependence. On failure (Add returns false), the caller (Builder layer)
+// should change the hash seed and retry from scratch.
+//
+// [RocksDB: BandingAdd in ribbon_impl.h]
+type bander interface {
+	// Add inserts a single key's equation (start, coeffRow, result) into
+	// the banded matrix via on-the-fly Gaussian elimination over GF(2).
+	//
+	// Returns true on successful insertion (the equation was placed in an
+	// empty slot). Returns false if the key's equation is linearly dependent
+	// on previously inserted equations — either redundant (c=0, r=0) or
+	// contradictory (c=0, r≠0). In both failure cases, the entire banding
+	// attempt must be restarted with a new seed.
+	Add(hr hashResult) bool
+
+	// AddRange inserts a batch of key equations, using software pipelining
+	// to prefetch the next key's start slot while processing the current
+	// key. Returns true if all insertions succeeded. Returns false on the
+	// first failure, leaving the bander in a partially-filled state.
+	//
+	// For large filters (coefficient array exceeds L1 cache), this hides
+	// L2/L3 memory latency and significantly improves throughput over
+	// calling Add() in a loop.
+	//
+	// [RocksDB: BandingAddRange in ribbon_alg.h]
+	AddRange(hrs []hashResult) bool
+
+	// reset clears all slots to their zero state, preparing the bander for
+	// a retry with a new hash seed. Does not reallocate — reuses the
+	// existing slot arrays.
+	reset()
+
+	// getSlot returns the bandingSlot at the given column index.
+	// Used by the back-substitution layer to read the final upper-triangular
+	// matrix. The caller must not access indices >= getNumSlots().
+	getSlot(i uint32) bandingSlot
+
+	// getNumSlots returns the total number of slots (columns) in the matrix.
+	// This equals numStarts + coeffBits - 1.
+	getNumSlots() uint32
+}
+
+// =============================================================================
+// STANDARD BANDER — implementation
+// =============================================================================
+
+// standardBander implements the bander interface using on-the-fly Gaussian
+// elimination over GF(2) with width-specialised inner loops.
+//
+// Paper §2: "For each key x, we attempt to insert its equation into the
+// banded matrix. If the pivot column is unoccupied, we store the equation.
+// If occupied, we XOR with the existing equation and repeat."
+//
+// Memory layout — Struct-of-Arrays (SoA):
+//
+// Instead of an Array-of-Structs ([]bandingSlot where each slot is 24 bytes
+// with 7 bytes of padding), the bander stores coefficient and result data
+// in parallel flat arrays:
+//
+//	coeffLo []uint64   — lower 64 bits of the coefficient row per slot
+//	coeffHi []uint64   — upper 64 bits (w=128 only; nil for w≤64)
+//	result  []uint8    — r-bit fingerprint per slot
+//
+// This layout provides two critical advantages:
+//
+//  1. For w≤64, coeffHi is nil. The elimination loop operates purely on
+//     uint64 values (coeffLo), avoiding all uint128 construction, shifting,
+//     and comparison overhead. Each slot's coefficient is a single 8-byte
+//     word instead of a 16-byte struct, doubling the number of coefficients
+//     per cache line (8 vs ~2.67 with AoS).
+//
+//  2. For w=128, the coeffLo and coeffHi arrays are separate but still
+//     contiguous. The loop accesses both sequentially within the narrow
+//     ribbon band (typically 128 slots wide), keeping the working set in
+//     L1 cache.
+//
+// Width-specialised Add:
+//
+// The Add() method dispatches to addW64() or addW128() based on whether
+// coeffHi is nil. This dispatch happens once per call (not per loop
+// iteration). The specialised methods avoid the generic uint128.rsh()
+// method (which has 4 branches for n≥128, n≥64, n=0, else) and instead
+// use direct uint64 shifts and TrailingZeros64 — compiling to a tight
+// TZCNT + LSR + EOR loop with no unnecessary branches.
+//
+// Configuration:
+//   - numSlots: total columns in the matrix (= numStarts + coeffBits - 1).
+//   - coeffBits: ribbon width w (32, 64, or 128).
+//   - backtrack: mirrors hasher.firstCoeffAlwaysOne(). When true, the
+//     first iteration of Add() skips the TrailingZeros intrinsic because
+//     bit 0 of the original coefficient row is guaranteed to be 1.
+//
+// [RocksDB: StandardBanding in ribbon_impl.h]
+type standardBander struct {
+	coeffLo   []uint64 // lo 64 bits of coefficient per slot; len = numSlots
+	coeffHi   []uint64 // hi 64 bits (w=128 only); nil for w≤64
+	result    []uint8  // r-bit result per slot; len = numSlots
+	numSlots  uint32   // total columns
+	backtrack bool     // firstCoeffAlwaysOne optimisation flag
+}
+
+// Compile-time check: *standardBander implements bander.
+var _ bander = (*standardBander)(nil)
+
+// newStandardBander creates a bander with the given configuration.
+//
+// Parameters:
+//   - numSlots: total columns in the banded matrix. Typically
+//     numStarts + coeffBits - 1, where numStarts ≈ N * (1 + 2.3/w).
+//     Paper §2: "the matrix has m columns (slots)."
+//   - coeffBits: ribbon width w — must be 32, 64, or 128.
+//   - firstCoeffAlwaysOne: when true, enables the fast-path optimisation
+//     in Add() that skips TrailingZeros on the first iteration.
+//
+// Panics if coeffBits is not 32, 64, or 128.
+func newStandardBander(numSlots, coeffBits uint32, firstCoeffAlwaysOne bool) *standardBander {
+	switch coeffBits {
+	case 32, 64, 128:
+		// valid
+	default:
+		panic("ribbon: coeffBits must be 32, 64, or 128")
+	}
+	b := &standardBander{
+		coeffLo:   make([]uint64, numSlots),
+		result:    make([]uint8, numSlots),
+		numSlots:  numSlots,
+		backtrack: firstCoeffAlwaysOne,
+	}
+	if coeffBits == 128 {
+		b.coeffHi = make([]uint64, numSlots)
+	}
+	return b
+}
+
+// =============================================================================
+// ADD — on-the-fly Gaussian elimination (hot path)
+// =============================================================================
+
+// Add inserts a single key's equation into the upper-triangular banded
+// matrix via on-the-fly Gaussian elimination over GF(2).
+//
+// Paper §2: given a key's triple (start s, coefficient row c ∈ {0,1}^w,
+// result r), the algorithm finds the lowest set bit of c (the "pivot"),
+// determines its absolute column index p = s + offset, and either:
+//
+//   - stores the equation at slot p if the slot is empty, or
+//   - XORs with the existing equation at slot p and repeats with the
+//     reduced equation.
+//
+// The XOR step is Gaussian elimination in GF(2): it zeros out the pivot
+// column in the current equation while preserving all other relationships.
+// Because XOR is its own inverse in GF(2), this is both addition and
+// subtraction.
+//
+// If the coefficient row becomes all-zero after XOR:
+//   - r = 0: the equation is redundant (linearly dependent, consistent).
+//   - r ≠ 0: the equation is contradictory (linearly dependent, inconsistent).
+//
+// In both c=0 cases, the insertion fails (returns false), signalling the
+// Builder layer to change the seed and restart.
+//
+// Performance: this is the hottest path in filter construction. The method
+// dispatches to a width-specialised inner loop:
+//   - w≤64: addW64() operates purely on uint64 — no uint128 overhead.
+//     One TZCNT + one LSR + one EOR per elimination step.
+//   - w=128: addW128() uses separate lo/hi uint64 operations, avoiding
+//     the generic uint128.rsh() branch ladder.
+//
+// Both paths are designed for:
+//   - Zero heap allocations: all values are stack-local or slice-indexed.
+//   - Minimal branching: the firstCoeffAlwaysOne fast path eliminates a
+//     TrailingZeros call on the first iteration.
+//   - CPU intrinsics: bits.TrailingZeros64 compiles to TZCNT/BSF.
+//   - Cache locality: SoA layout maximises coefficients per cache line.
+//
+// [RocksDB: BandingAdd in ribbon_impl.h]
+func (b *standardBander) Add(hr hashResult) bool {
+	if b.coeffHi != nil {
+		return b.addW128(hr)
+	}
+	return b.addW64(hr)
+}
+
+// addW64 is the width-specialised Add for w≤64 (w=32 or w=64).
+//
+// Operates purely on uint64 coefficient values — no uint128 construction,
+// no generic rsh() with its 4-branch dispatch, no hi-half operations.
+// The inner loop is a tight sequence:
+//
+//	TZCNT → LSR → load coeffLo[p] → CBZ → EOR → CBZ → loop
+//
+// This compiles to ~10 ARM64 instructions per elimination step, compared
+// to ~25+ for the generic uint128 path.
+//
+// Performance: with the SoA layout, 8 coefficient uint64 values fit in a
+// single 64-byte cache line (vs ~2.67 bandingSlot structs with AoS).
+// For the common case (first probe hits an empty slot), this means the
+// coefficient check is almost always an L1 hit.
+func (b *standardBander) addW64(hr hashResult) bool {
+	s := hr.start
+	c := hr.coeffRow.lo
+	r := hr.result
+	coeffs := b.coeffLo
+	results := b.result
+
+	// -------------------------------------------------------------------------
+	// Fast path: firstCoeffAlwaysOne optimisation.
+	//
+	// When the hasher guarantees bit 0 of the coefficient row is always 1,
+	// the pivot offset for the *first* iteration is known to be 0. This
+	// skips the TrailingZeros64 intrinsic and the right-shift for the most
+	// common case (the first probe often succeeds for well-sized filters).
+	//
+	// Paper §4: "setting the first coefficient bit to 1 … makes the
+	// Gaussian elimination pivot deterministic at column s(x)."
+	// -------------------------------------------------------------------------
+	if b.backtrack {
+		// Pivot offset i=0, absolute pivot column p=s.
+		existing := coeffs[s]
+		if existing == 0 {
+			// Empty slot — store the equation directly.
+			coeffs[s] = c
+			results[s] = r
+			return true
+		}
+		// Collision: XOR with existing equation to eliminate column s.
+		// Both c and existing have bit 0 = 1, so XOR zeroes bit 0.
+		// This is Gaussian elimination in GF(2): the pivot column is
+		// eliminated, and the remaining bits encode the reduced equation.
+		c ^= existing
+		r ^= results[s]
+		if c == 0 {
+			// Linear dependence detected:
+			//   r=0 → redundant (consistent but provides no new information)
+			//   r≠0 → contradictory (inconsistent system)
+			// Either way, this key cannot be inserted. Signal failure.
+			return false
+		}
+		// After XOR: bit 0 is now 0 (both operands had bit 0 = 1).
+		// Fall through to the generic loop, which will find the next pivot
+		// at TrailingZeros64(c) ≥ 1.
+	}
+
+	// -------------------------------------------------------------------------
+	// Generic Gaussian elimination loop (uint64 fast path).
+	//
+	// Invariant: c is non-zero at loop entry. Each iteration:
+	//   1. Find the lowest set bit i = TrailingZeros64(c).
+	//   2. Compute absolute pivot column p = s + i.
+	//   3. Right-shift c by i so bit 0 becomes the pivot (always 1).
+	//   4. Probe coeffs[p]:
+	//      - Zero (empty) → store (c, r), return true.
+	//      - Non-zero (occupied) → XOR to eliminate pivot, check for zero.
+	//
+	// The right-shift ensures that stored coefficients always have bit 0 = 1,
+	// maintaining the upper-triangular structure: coeffs[p]'s pivot is at
+	// column p, with remaining non-zero bits in columns p+1, p+2, ….
+	// -------------------------------------------------------------------------
+	for {
+		// Step 1–2: Find pivot offset via trailing zeros.
+		// Compiles to a single TZCNT (ARM64: RBIT+CLZ) instruction.
+		i := uint(bits.TrailingZeros64(c))
+
+		// Step 3: Shift to make the pivot bit 0, advance start.
+		p := s + uint32(i)
+		c >>= i
+
+		// Step 4: Probe the coefficient slot at the pivot column.
+		existing := coeffs[p]
+		if existing == 0 {
+			// Empty slot — store the (shifted) equation.
+			coeffs[p] = c
+			results[p] = r
+			return true
+		}
+
+		// Collision: XOR with the existing equation at coeffs[p].
+		// Both c and existing have bit 0 = 1, so XOR zeroes the
+		// pivot column. The result is a reduced equation with its next
+		// pivot at some column > p.
+		c ^= existing
+		r ^= results[p]
+		s = p
+		if c == 0 {
+			return false
+		}
+		// Loop continues with the reduced equation.
+	}
+}
+
+// addW128 is the width-specialised Add for w=128.
+//
+// Uses separate lo/hi uint64 operations to avoid the generic uint128.rsh()
+// method which has a 4-branch dispatch (n≥128, n≥64, n=0, else). Instead,
+// the shift is split into two cases: pivot in lo half (i<64) and pivot in
+// hi half (i≥64), each producing branchless shift code.
+//
+// The TrailingZeros scan checks lo first — for most random coefficients,
+// lo is non-zero (P=1-2^-64), so the hi half is rarely touched.
+//
+// Occupancy check: uses (eLo | eHi) == 0 instead of separate comparisons.
+// This generates a single ORR + CBZ sequence on ARM64 — one fewer branch
+// than checking each half individually.
+func (b *standardBander) addW128(hr hashResult) bool {
+	s := hr.start
+	cLo := hr.coeffRow.lo
+	cHi := hr.coeffRow.hi
+	r := hr.result
+	coeffLo := b.coeffLo
+	coeffHi := b.coeffHi
+	results := b.result
+
+	// Fast path: firstCoeffAlwaysOne.
+	if b.backtrack {
+		eLo := coeffLo[s]
+		eHi := coeffHi[s]
+		if eLo|eHi == 0 {
+			coeffLo[s] = cLo
+			coeffHi[s] = cHi
+			results[s] = r
+			return true
+		}
+		cLo ^= eLo
+		cHi ^= eHi
+		r ^= results[s]
+		if cLo|cHi == 0 {
+			return false
+		}
+	}
+
+	// Generic loop.
+	for {
+		// Find pivot: check lo first (almost always non-zero for random coeffs).
+		var i uint
+		if cLo != 0 {
+			i = uint(bits.TrailingZeros64(cLo))
+		} else {
+			i = 64 + uint(bits.TrailingZeros64(cHi))
+		}
+		p := s + uint32(i)
+
+		// Right-shift {cHi, cLo} by i bits.
+		// Two cases avoid the generic rsh() 4-branch ladder:
+		//   i < 64: pivot in lo half — both halves shift normally.
+		//   i ≥ 64: pivot in hi half — lo gets hi's bits, hi becomes 0.
+		if i < 64 {
+			if i > 0 {
+				cLo = (cLo >> i) | (cHi << (64 - i))
+				cHi >>= i
+			}
+		} else {
+			cLo = cHi >> (i - 64)
+			cHi = 0
+		}
+
+		eLo := coeffLo[p]
+		eHi := coeffHi[p]
+		if eLo|eHi == 0 {
+			coeffLo[p] = cLo
+			coeffHi[p] = cHi
+			results[p] = r
+			return true
+		}
+
+		cLo ^= eLo
+		cHi ^= eHi
+		r ^= results[p]
+		s = p
+		if cLo|cHi == 0 {
+			return false
+		}
+	}
+}
+
+// =============================================================================
+// ADD RANGE — batched insertion with software-pipelined prefetching
+// =============================================================================
+
+// AddRange inserts a batch of key equations into the banded matrix,
+// using software pipelining to prefetch the next key's start slot while
+// processing the current key.
+//
+// Returns true if all insertions succeeded. Returns false on the first
+// failure (linear dependence), at which point the bander is in a
+// partially-filled state and the caller should reset and retry with a
+// new seed.
+//
+// Prefetching rationale (Paper §4, RocksDB: BandingAddRange):
+//
+// When the coefficient array exceeds L1 cache (numSlots > ~8K for w≤64,
+// ~4K for w=128), each key's start position maps to a random cache line.
+// Without prefetching, every first probe in Add() is a guaranteed L2 or
+// L3 miss (~4–40 ns penalty depending on array size).
+//
+// AddRange pipelines memory access: while processing key[i], it issues a
+// load for coeffs[key[i+1].start]. By the time key[i]'s elimination
+// completes (~5–7 ns), the next key's cache line is already in L1. This
+// converts random L2/L3 misses into L1 hits for the common first-probe
+// case (which dominates for well-sized filters).
+//
+// For small filters that fit in L1 (<~8K slots), the extra load is a
+// harmless no-op — the data is already cached.
+//
+// [RocksDB: BandingAddRange in ribbon_alg.h, Prefetch in ribbon_impl.h]
+func (b *standardBander) AddRange(hrs []hashResult) bool {
+	if b.coeffHi != nil {
+		return b.addRangeW128(hrs)
+	}
+	return b.addRangeW64(hrs)
+}
+
+// addRangeW64 is the batched, prefetching variant of addW64 for w≤64.
+//
+// The function processes keys sequentially with a one-ahead prefetch
+// pattern matching RocksDB's BandingAddRange:
+//
+//  1. Before entering the loop, prefetch key[0]'s start slot.
+//  2. At the top of each iteration, prefetch key[i+1]'s start slot.
+//  3. Process key[i] using the same Gaussian elimination as addW64.
+//
+// The prefetch is implemented as a dummy load (`_ = coeffs[nextStart]`)
+// which the Go compiler must emit because slice indexing may panic
+// (observable side effect). The CPU fetches the containing cache line,
+// hiding memory latency.
+//
+// [RocksDB: BandingAddRange in ribbon_alg.h]
+func (b *standardBander) addRangeW64(hrs []hashResult) bool {
+	coeffs := b.coeffLo
+	results := b.result
+	n := len(hrs)
+	if n == 0 {
+		return true
+	}
+
+	// Prefetch first key's start slot into L1 cache.
+	_ = coeffs[hrs[0].start]
+
+	for idx := 0; idx < n; idx++ {
+		// Software-pipelined prefetch: load next key's start slot into
+		// cache while processing the current key. The ~5–7 ns of
+		// elimination work on key[idx] gives the memory subsystem time
+		// to fetch the cache line for key[idx+1].
+		if idx+1 < n {
+			_ = coeffs[hrs[idx+1].start]
+		}
+
+		s := hrs[idx].start
+		c := hrs[idx].coeffRow.lo
+		r := hrs[idx].result
+
+		// Fast path: firstCoeffAlwaysOne.
+		if b.backtrack {
+			existing := coeffs[s]
+			if existing == 0 {
+				coeffs[s] = c
+				results[s] = r
+				continue
+			}
+			c ^= existing
+			r ^= results[s]
+			if c == 0 {
+				return false
+			}
+		}
+
+		// Generic elimination loop (same as addW64).
+		success := false
+		for {
+			i := uint(bits.TrailingZeros64(c))
+			p := s + uint32(i)
+			c >>= i
+
+			existing := coeffs[p]
+			if existing == 0 {
+				coeffs[p] = c
+				results[p] = r
+				success = true
+				break
+			}
+
+			c ^= existing
+			r ^= results[p]
+			s = p
+			if c == 0 {
+				break
+			}
+		}
+		if !success {
+			return false
+		}
+	}
+	return true
+}
+
+// addRangeW128 is the batched, prefetching variant of addW128 for w=128.
+//
+// Prefetches both coeffLo and coeffHi for the next key, since w=128
+// requires reading both arrays during elimination.
+//
+// [RocksDB: BandingAddRange in ribbon_alg.h]
+func (b *standardBander) addRangeW128(hrs []hashResult) bool {
+	coeffLo := b.coeffLo
+	coeffHi := b.coeffHi
+	results := b.result
+	n := len(hrs)
+	if n == 0 {
+		return true
+	}
+
+	// Prefetch first key's start slot (both lo and hi arrays).
+	_ = coeffLo[hrs[0].start]
+	_ = coeffHi[hrs[0].start]
+
+	for idx := 0; idx < n; idx++ {
+		if idx+1 < n {
+			nextStart := hrs[idx+1].start
+			_ = coeffLo[nextStart]
+			_ = coeffHi[nextStart]
+		}
+
+		s := hrs[idx].start
+		cLo := hrs[idx].coeffRow.lo
+		cHi := hrs[idx].coeffRow.hi
+		r := hrs[idx].result
+
+		// Fast path: firstCoeffAlwaysOne.
+		if b.backtrack {
+			eLo := coeffLo[s]
+			eHi := coeffHi[s]
+			if eLo|eHi == 0 {
+				coeffLo[s] = cLo
+				coeffHi[s] = cHi
+				results[s] = r
+				continue
+			}
+			cLo ^= eLo
+			cHi ^= eHi
+			r ^= results[s]
+			if cLo|cHi == 0 {
+				return false
+			}
+		}
+
+		// Generic elimination loop (same as addW128).
+		success := false
+		for {
+			var i uint
+			if cLo != 0 {
+				i = uint(bits.TrailingZeros64(cLo))
+			} else {
+				i = 64 + uint(bits.TrailingZeros64(cHi))
+			}
+			p := s + uint32(i)
+
+			if i < 64 {
+				if i > 0 {
+					cLo = (cLo >> i) | (cHi << (64 - i))
+					cHi >>= i
+				}
+			} else {
+				cLo = cHi >> (i - 64)
+				cHi = 0
+			}
+
+			eLo := coeffLo[p]
+			eHi := coeffHi[p]
+			if eLo|eHi == 0 {
+				coeffLo[p] = cLo
+				coeffHi[p] = cHi
+				results[p] = r
+				success = true
+				break
+			}
+
+			cLo ^= eLo
+			cHi ^= eHi
+			r ^= results[p]
+			s = p
+			if cLo|cHi == 0 {
+				break
+			}
+		}
+		if !success {
+			return false
+		}
+	}
+	return true
+}
+
+// =============================================================================
+// SLOW ADD — unoptimised reference implementation
+// =============================================================================
+
+// slowAdd is the unoptimised reference implementation of Add.
+//
+// It always uses TrailingZeros (no firstCoeffAlwaysOne fast path, no
+// width specialisation) and follows the textbook Gaussian elimination
+// algorithm step by step. This serves as:
+//   - A correctness oracle for cross-validation tests.
+//   - Documentation of the canonical algorithm before optimisation.
+//
+// The output must be identical to Add for all inputs.
+func (b *standardBander) slowAdd(hr hashResult) bool {
+	s := hr.start
+	c := hr.coeffRow
+	r := hr.result
+
+	for {
+		// Find pivot: lowest set bit.
+		i := c.trailingZeros()
+
+		// Absolute pivot column.
+		p := s + uint32(i)
+
+		// Right-shift so bit 0 = pivot.
+		c = c.rsh(i)
+		s = p
+
+		// Read slot via SoA arrays.
+		eLo := b.coeffLo[p]
+		eHi := uint64(0)
+		if b.coeffHi != nil {
+			eHi = b.coeffHi[p]
+		}
+
+		if eLo == 0 && eHi == 0 {
+			// Empty — store.
+			b.coeffLo[p] = c.lo
+			if b.coeffHi != nil {
+				b.coeffHi[p] = c.hi
+			}
+			b.result[p] = r
+			return true
+		}
+
+		// XOR to eliminate pivot column.
+		c = c.xor(uint128{hi: eHi, lo: eLo})
+		r ^= b.result[p]
+
+		if c.isZero() {
+			return false
+		}
+	}
+}
+
+// slowAddRange is the unoptimised reference implementation of AddRange.
+// It simply loops over slowAdd with no prefetching, serving as a
+// correctness oracle for cross-validation tests.
+func (b *standardBander) slowAddRange(hrs []hashResult) bool {
+	for _, hr := range hrs {
+		if !b.slowAdd(hr) {
+			return false
+		}
+	}
+	return true
+}
+
+// =============================================================================
+// ACCESSORS & UTILITIES
+// =============================================================================
+
+// reset clears all slots to their zero state (coeff=0, result=0),
+// preparing the bander for a retry with a new hash seed.
+//
+// Uses Go's built-in clear() which compiles to an optimised memset,
+// zeroing each array in one pass without per-element branching.
+func (b *standardBander) reset() {
+	clear(b.coeffLo)
+	if b.coeffHi != nil {
+		clear(b.coeffHi)
+	}
+	clear(b.result)
+}
+
+// getSlot returns the bandingSlot at the given column index.
+// Used by back-substitution to read the upper-triangular matrix.
+//
+// Panics if i >= numSlots (programmer error — the caller must respect bounds).
+func (b *standardBander) getSlot(i uint32) bandingSlot {
+	hi := uint64(0)
+	if b.coeffHi != nil {
+		hi = b.coeffHi[i]
+	}
+	return bandingSlot{
+		coeffRow: uint128{hi: hi, lo: b.coeffLo[i]},
+		result:   b.result[i],
+	}
+}
+
+// getNumSlots returns the total number of columns (slots) in the matrix.
+func (b *standardBander) getNumSlots() uint32 {
+	return b.numSlots
+}

--- a/bander_bench_test.go
+++ b/bander_bench_test.go
@@ -1,0 +1,320 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// Benchmarks — banding (Gaussian elimination) hot path
+//
+// The Add() method is the innermost loop of filter construction. For each
+// key, it performs on-the-fly Gaussian elimination over GF(2): finding the
+// pivot (TrailingZeros), probing the slot, and XOR-reducing on collision.
+//
+// The benchmark pre-computes hashResult values so that the measured time
+// is strictly the Gaussian elimination logic — no hashing overhead.
+//
+// We benchmark:
+//   1. Add()        — per-key amortised cost of Gaussian elimination.
+//   2. Add() with high load — measures collision chain impact.
+//
+// Each is measured across ribbon widths (32/64/128), with and without
+// firstCoeffAlwaysOne, to surface any width-dependent or optimisation cost.
+// =============================================================================
+
+// benchHashResults generates N pre-computed hashResult values for benchmarking.
+// Uses deterministic keys and seed 0.
+func benchHashResults(w, numStarts uint32, fcao bool, n int) []hashResult {
+	h := newStandardHasher(w, numStarts, 7, fcao)
+	h.setOrdinalSeed(0)
+	results := make([]hashResult, n)
+	for i := range results {
+		kh := h.keyHash([]byte(fmt.Sprintf("bench_bander_key_%d", i)))
+		results[i] = h.derive(kh)
+	}
+	return results
+}
+
+// ---------------------------------------------------------------------------
+// 1. Add — per-key amortised Gaussian elimination cost
+//
+// Inserts keys into a well-sized bander (numStarts >> numKeys) to minimise
+// collision chains and measure the common-case single-probe fast path.
+// The bander is reset every cycle to keep conditions consistent.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   fcao     ns/op   allocs/op
+//   ─────   ─────    ─────   ─────────
+//   w=32    true      4.99   0
+//   w=32    false     5.71   0
+//   w=64    true      4.99   0
+//   w=64    false     5.73   0
+//   w=128   true      6.67   0
+//   w=128   false     7.33   0
+//
+// Key observations:
+//   • Zero allocations — all values are stack-local or slice-indexed.
+//   • SoA layout + width-specialised addW64/addW128: w≤64 now operates
+//     purely on uint64 with no uint128 overhead — ~5.0 ns/key vs ~5.3
+//     in v1 AoS (~6% faster).
+//   • fcao gap narrowed dramatically for w≤64: ~14% (5.0→5.7) vs ~40%
+//     in v1. The uint64 fast path has far less work to skip.
+//   • w=128 is now measurably slower than w≤64 (6.7 vs 5.0 ns, +34%)
+//     because addW128 requires two uint64 operations per step. In v1
+//     all widths were ~equal because all used the same uint128 path.
+//   • ~5.0 ns/key (w≤64, fcao=true) translates to ~200M insertions/sec.
+// ---------------------------------------------------------------------------
+
+func BenchmarkAdd(b *testing.B) {
+	const numKeys = 4096 // power-of-2 for cheap masking
+
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			b.Run(name, func(b *testing.B) {
+				numStarts := uint32(10000)
+				numSlots := numStarts + w - 1
+				hashes := benchHashResults(w, numStarts, fcao, numKeys)
+				bd := newStandardBander(numSlots, w, fcao)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					idx := i & (numKeys - 1)
+					if idx == 0 {
+						bd.reset()
+					}
+					sink = bd.Add(hashes[idx])
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Add under high load — collision chain impact
+//
+// Uses tighter sizing (numStarts ≈ 1.1 * numKeys) so that collision chains
+// are more frequent. This benchmarks the worst-case inner loop (multiple
+// XOR iterations per Add call).
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   ns/op   allocs/op
+//   ─────   ─────   ─────────
+//   w=64    12.44   0
+//   w=128   16.39   0
+//
+// Key observations:
+//   • ~45% faster than v1 AoS (12.4 vs 22.8 for w=64, 16.4 vs 23.0 for
+//     w=128). The SoA layout's improved cache density dominates here:
+//     collision chains probe multiple sequential slots, and 8 uint64
+//     coefficients per cache line (vs ~2.67 bandingSlot structs) means
+//     far fewer L1 misses during chain traversal.
+//   • Still zero allocations — the inner XOR loop is entirely stack-local.
+//   • w=64 is now faster than w=128 (12.4 vs 16.4 ns, ~24%) because
+//     addW64 avoids all hi-half operations during the XOR chain.
+// ---------------------------------------------------------------------------
+
+func BenchmarkAddHighLoad(b *testing.B) {
+	const numKeys = 4096
+
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			// Tight sizing: ~10% overhead.
+			n := numKeys // avoid constant folding
+			numStarts := uint32(float64(n)*1.1) + 1
+			numSlots := numStarts + w - 1
+			hashes := benchHashResults(w, numStarts, true, numKeys)
+			bd := newStandardBander(numSlots, w, true)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				idx := i & (numKeys - 1)
+				if idx == 0 {
+					bd.reset()
+				}
+				sink = bd.Add(hashes[idx])
+			}
+			_ = sink
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Full banding pass — throughput benchmark
+//
+// Simulates a complete banding pass: insert all N keys, measure wall-clock
+// time and report keys/op throughput. This is the most realistic benchmark
+// as it captures the actual mix of fast-path hits and collision chains.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   ns/op      keys/op   ~keys/sec     allocs/op
+//   ─────   ────────   ───────   ──────────    ─────────
+//   w=64     70,865    10,000    ~141M         0
+//   w=128   111,909    10,000    ~89.4M        0
+//
+// Key observations:
+//   • ~2× throughput improvement over v1 AoS (141M vs 68.4M keys/sec
+//     for w=64; 89.4M vs 67.4M for w=128).
+//   • ~7.1 ns/key amortised for w=64 over a full pass — the mix of
+//     fast-path hits and collision chains. The SoA cache advantage
+//     compounds over the full pass as the matrix fills.
+//   • ~141M keys/sec (w=64) means a 1M-key filter's banding pass
+//     takes ~7.1 ms per seed attempt (excluding derive() cost).
+//   • w=64 is ~37% faster than w=128, reflecting the addW64 advantage.
+// ---------------------------------------------------------------------------
+
+func BenchmarkBandingPassThroughput(b *testing.B) {
+	const numKeys = 10000
+
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			// Generous sizing so the pass almost always succeeds.
+			numStarts := uint32(float64(numKeys) * 1.2)
+			numSlots := numStarts + w - 1
+			hashes := benchHashResults(w, numStarts, true, numKeys)
+			bd := newStandardBander(numSlots, w, true)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				bd.reset()
+				for _, hr := range hashes {
+					sink = bd.Add(hr)
+				}
+			}
+			_ = sink
+			b.ReportMetric(float64(numKeys), "keys/op")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Banding pass comparison — Add-loop vs AddRange (prefetching)
+//
+// Compares a plain Add-loop against AddRange (with software-pipelined
+// prefetching) for full banding passes at two scales:
+//
+//   • 10K keys (~80KB coefficient array for w≤64) — fits in L1.
+//     Prefetching should be a no-op; both methods equivalent.
+//
+//   • 100K keys (~800KB coefficient array for w≤64) — exceeds L1,
+//     lives in L2. Prefetching converts random L2 misses into L1 hits,
+//     showing a measurable throughput improvement.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Keys     Width   Method      ns/op        keys/op   ~keys/sec     allocs/op
+//   ──────   ─────   ──────      ──────────   ───────   ──────────    ─────────
+//   10K      w=64    Add-loop       71,574    10,000    ~140M         0
+//   10K      w=64    AddRange       52,725    10,000    ~190M         0
+//   10K      w=128   Add-loop      110,234    10,000    ~90.7M        0
+//   10K      w=128   AddRange       94,640    10,000    ~106M         0
+//   100K     w=64    Add-loop    1,835,023    100,000   ~54.5M        0
+//   100K     w=64    AddRange    1,466,061    100,000   ~68.2M        0
+//   100K     w=128   Add-loop    2,182,444    100,000   ~45.8M        0
+//   100K     w=128   AddRange    1,954,879    100,000   ~51.2M        0
+//
+// Key observations:
+//   • 10K/w=64: AddRange is ~26% faster (52.7 vs 71.6 µs). Even though
+//     the 80KB coefficient array fits in L1, the prefetch eliminates
+//     the overhead of method-call dispatch per key (AddRange inlines
+//     the full elimination loop and amortises slice header loads).
+//   • 100K/w=64: AddRange is ~20% faster (1.47 vs 1.84 ms). At 800KB,
+//     the coefficient array spills to L2 — prefetching converts random
+//     L2 misses into L1 hits on the common first-probe path.
+//   • w=128 benefits less (~14–11%) because the elimination loop does
+//     more work per key (two uint64 ops per step), leaving less time
+//     for the prefetch to complete before the next key's access.
+//   • Zero allocations in all cases.
+// ---------------------------------------------------------------------------
+
+func BenchmarkBandingPassComparison(b *testing.B) {
+	for _, numKeys := range []int{10000, 100000} {
+		for _, w := range []uint32{64, 128} {
+			n := numKeys // avoid constant folding with float64(numKeys)
+			numStarts := uint32(float64(n)*1.2) + 1
+			numSlots := numStarts + w - 1
+			hashes := benchHashResults(w, numStarts, true, numKeys)
+
+			b.Run(fmt.Sprintf("keys=%d/w=%d/Add-loop", numKeys, w), func(b *testing.B) {
+				bd := newStandardBander(numSlots, w, true)
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					bd.reset()
+					for _, hr := range hashes {
+						sink = bd.Add(hr)
+					}
+				}
+				_ = sink
+				b.ReportMetric(float64(numKeys), "keys/op")
+			})
+
+			b.Run(fmt.Sprintf("keys=%d/w=%d/AddRange", numKeys, w), func(b *testing.B) {
+				bd := newStandardBander(numSlots, w, true)
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					bd.reset()
+					sink = bd.AddRange(hashes)
+				}
+				_ = sink
+				b.ReportMetric(float64(numKeys), "keys/op")
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Reset — cost of clearing the slot array
+//
+// Measures the cost of clear(slots) for various slot array sizes.
+// This is called once per seed retry, so it should be fast relative to
+// the full banding pass.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Slots      ns/op     allocs/op
+//   ──────     ───────   ─────────
+//   1,000      162       0
+//   10,000     1,514     0
+//   100,000    15,353    0
+//
+// Key observations:
+//   • Scales linearly with slot count — clear() compiles to memset.
+//   • ~25% faster than v1 AoS reset: SoA clears three flat arrays
+//     (coeffLo + coeffHi + result) instead of one array of 24-byte
+//     structs with 7 bytes padding per element. Less total memory
+//     to zero (17 bytes/slot for w=128, 9 bytes/slot for w≤64
+//     vs 24 bytes/slot for AoS).
+//   • 10K slots: 1.5 µs — negligible vs a banding pass (~71 µs).
+//   • 100K slots: 15 µs — still <22% of a 100K-key pass.
+// ---------------------------------------------------------------------------
+
+func BenchmarkReset(b *testing.B) {
+	for _, numSlots := range []uint32{1000, 10000, 100000} {
+		name := fmt.Sprintf("slots=%d", numSlots)
+		b.Run(name, func(b *testing.B) {
+			bd := newStandardBander(numSlots, 128, true)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				bd.reset()
+			}
+		})
+	}
+}

--- a/bander_test.go
+++ b/bander_test.go
@@ -1,0 +1,804 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+// newTestBander creates a standardBander with common test defaults.
+// Uses numSlots = numStarts + coeffBits - 1, with generous over-provisioning
+// so that typical random insertions succeed reliably.
+func newTestBander(coeffBits uint32, firstCoeffAlwaysOne bool) *standardBander {
+	numStarts := uint32(10000)
+	numSlots := numStarts + coeffBits - 1
+	return newStandardBander(numSlots, coeffBits, firstCoeffAlwaysOne)
+}
+
+// newTestHasherForBander creates a standardHasher matching a bander's config.
+func newTestHasherForBander(coeffBits uint32, numStarts uint32, firstCoeffAlwaysOne bool) *standardHasher {
+	return newStandardHasher(coeffBits, numStarts, 7, firstCoeffAlwaysOne)
+}
+
+// precomputedHashResults generates N deterministic hashResult values
+// using the given hasher. Removes Phase 1 (XXH3) and Phase 2 (derive)
+// from the code under test — isolates banding logic.
+func precomputedHashResults(h *standardHasher, n int) []hashResult {
+	results := make([]hashResult, n)
+	for i := range results {
+		kh := h.keyHash([]byte(fmt.Sprintf("bander_key_%d", i)))
+		results[i] = h.derive(kh)
+	}
+	return results
+}
+
+// =============================================================================
+// CONSTRUCTOR TESTS
+// =============================================================================
+
+func TestNewStandardBander(t *testing.T) {
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				numSlots := uint32(1000) + w - 1
+				bd := newStandardBander(numSlots, w, fcao)
+
+				if bd.getNumSlots() != numSlots {
+					t.Errorf("numSlots = %d, want %d", bd.getNumSlots(), numSlots)
+				}
+				if uint32(len(bd.coeffLo)) != numSlots {
+					t.Errorf("len(coeffLo) = %d, want %d", len(bd.coeffLo), numSlots)
+				}
+
+				// All slots should be empty (zero-valued).
+				for i := uint32(0); i < numSlots; i++ {
+					slot := bd.getSlot(i)
+					if !slot.coeffRow.isZero() || slot.result != 0 {
+						t.Fatalf("slot[%d] not empty after construction", i)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestNewStandardBander_InvalidCoeffBits(t *testing.T) {
+	for _, w := range []uint32{0, 16, 48, 96, 256} {
+		w := w
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("newStandardBander with coeffBits=%d should panic", w)
+				}
+			}()
+			newStandardBander(100, w, true)
+		})
+	}
+}
+
+// =============================================================================
+// ADD — basic insertion tests
+// =============================================================================
+
+func TestAdd_SingleInsertion(t *testing.T) {
+	// Insert a single key into each configuration. Must always succeed.
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				bd := newTestBander(w, fcao)
+				numStarts := uint32(10000)
+				h := newTestHasherForBander(w, numStarts, fcao)
+				h.setOrdinalSeed(0)
+
+				kh := h.keyHash([]byte("single_key"))
+				hr := h.derive(kh)
+
+				ok := bd.Add(hr)
+				if !ok {
+					t.Fatal("Add returned false for single key insertion")
+				}
+
+				// Verify the pivot slot is occupied.
+				// The pivot column depends on firstCoeffAlwaysOne:
+				// if true, pivot = start (bit 0 is always 1).
+				if fcao {
+					slot := bd.getSlot(hr.start)
+					if slot.coeffRow.isZero() {
+						t.Error("slot at start position is empty after insertion")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAdd_MultipleNonConflicting(t *testing.T) {
+	// Insert many keys with a well-sized filter. Most should succeed.
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				numStarts := uint32(10000)
+				numSlots := numStarts + w - 1
+				bd := newStandardBander(numSlots, w, fcao)
+				h := newTestHasherForBander(w, numStarts, fcao)
+				h.setOrdinalSeed(0)
+
+				const numKeys = 500
+				successes := 0
+				for i := 0; i < numKeys; i++ {
+					kh := h.keyHash([]byte(fmt.Sprintf("key_%d", i)))
+					hr := h.derive(kh)
+					if bd.Add(hr) {
+						successes++
+					}
+				}
+
+				// With 10000 slots and only 500 keys, virtually all
+				// should succeed (failure rate < 0.1%).
+				if successes < numKeys-5 {
+					t.Errorf("too many failures: %d/%d succeeded", successes, numKeys)
+				}
+				t.Logf("%d/%d insertions succeeded", successes, numKeys)
+			})
+		}
+	}
+}
+
+// =============================================================================
+// ADD — linear dependence tests (c=0 failure states)
+// =============================================================================
+
+func TestAdd_RedundantEquation(t *testing.T) {
+	// Insert the same hashResult twice. The second insertion should fail
+	// with c=0, r=0 (redundant — the equation is already represented).
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				bd := newTestBander(w, fcao)
+				numStarts := uint32(10000)
+				h := newTestHasherForBander(w, numStarts, fcao)
+				h.setOrdinalSeed(0)
+
+				kh := h.keyHash([]byte("duplicate"))
+				hr := h.derive(kh)
+
+				// First insertion succeeds.
+				if !bd.Add(hr) {
+					t.Fatal("first Add failed")
+				}
+
+				// Second insertion of the same equation: c XOR c = 0, r XOR r = 0.
+				ok := bd.Add(hr)
+				if ok {
+					t.Error("second Add of same hashResult should return false (redundant)")
+				}
+			})
+		}
+	}
+}
+
+func TestAdd_ContradictoryEquation(t *testing.T) {
+	// Craft two equations with the same start and coeffRow but different
+	// result. This forces c=0, r≠0 (contradictory — no solution exists).
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				bd := newTestBander(w, fcao)
+
+				// Choose a coefficient with bit 0 = 1 (to work with both
+				// fcao=true and fcao=false).
+				var coeff uint128
+				switch w {
+				case 32:
+					coeff = uint128{lo: 0xDEADBEEF & 0xFFFFFFFF}
+				case 64:
+					coeff = uint128{lo: 0xDEADBEEFCAFEBABE}
+				case 128:
+					coeff = uint128{hi: 0x0123456789ABCDEF, lo: 0xDEADBEEFCAFEBABE}
+				}
+				// Ensure bit 0 is set (required for valid equation).
+				coeff.lo |= 1
+
+				hr1 := hashResult{start: 100, coeffRow: coeff, result: 42}
+				hr2 := hashResult{start: 100, coeffRow: coeff, result: 99}
+
+				if !bd.Add(hr1) {
+					t.Fatal("first Add failed")
+				}
+
+				ok := bd.Add(hr2)
+				if ok {
+					t.Error("contradictory equation should return false")
+				}
+			})
+		}
+	}
+}
+
+func TestAdd_MultiStepCollisionChain(t *testing.T) {
+	// Craft equations that force a multi-step collision chain during
+	// elimination, eventually resulting in linear dependence (c=0).
+	//
+	// Setup for w=64, fcao=true:
+	//   eq1: start=10, coeff=0b...0001 (pivot at col 10)
+	//   eq2: start=10, coeff=0b...0011 (pivot at col 10 → XOR with eq1 → coeff=0b...0010, pivot at col 11)
+	//   eq3: start=10, coeff=0b...0011, same result as eq2 → same chain → c=0, r=0
+	for _, fcao := range []bool{true, false} {
+		name := fmt.Sprintf("fcao=%v", fcao)
+		t.Run(name, func(t *testing.T) {
+			bd := newStandardBander(100, 64, fcao)
+
+			eq1 := hashResult{
+				start:    10,
+				coeffRow: uint128{lo: 0b0001},
+				result:   5,
+			}
+			eq2 := hashResult{
+				start:    10,
+				coeffRow: uint128{lo: 0b0011},
+				result:   7,
+			}
+			// eq3 is identical to eq2 — same start, coeff, result.
+			// Chain: pivot at 10 → XOR with eq1 → coeff=0b0010 → pivot at 11
+			//        → XOR with eq2's remainder → c=0, r=0.
+			eq3 := hashResult{
+				start:    10,
+				coeffRow: uint128{lo: 0b0011},
+				result:   7,
+			}
+
+			if !bd.Add(eq1) {
+				t.Fatal("eq1 Add failed")
+			}
+			if !bd.Add(eq2) {
+				t.Fatal("eq2 Add failed")
+			}
+
+			ok := bd.Add(eq3)
+			if ok {
+				t.Error("eq3 should fail (redundant after multi-step chain)")
+			}
+		})
+	}
+}
+
+func TestAdd_ChainResolves(t *testing.T) {
+	// A collision chain that resolves successfully — two keys collide at
+	// the same start but the XOR produces a non-zero coefficient with a
+	// different pivot, which finds an empty slot.
+	for _, fcao := range []bool{true, false} {
+		name := fmt.Sprintf("fcao=%v", fcao)
+		t.Run(name, func(t *testing.T) {
+			bd := newStandardBander(100, 64, fcao)
+
+			eq1 := hashResult{
+				start:    10,
+				coeffRow: uint128{lo: 0b0101}, // bits 0 and 2 set
+				result:   3,
+			}
+			eq2 := hashResult{
+				start:    10,
+				coeffRow: uint128{lo: 0b0111}, // bits 0, 1, and 2 set
+				result:   5,
+			}
+
+			if !bd.Add(eq1) {
+				t.Fatal("eq1 Add failed")
+			}
+			// eq2 collides with eq1 at col 10. XOR: 0b0101 ^ 0b0111 = 0b0010.
+			// New pivot at col 11 (bit 1). Shift right by 1 → coeff=0b0001.
+			// Slot 11 is empty → store successfully.
+			if !bd.Add(eq2) {
+				t.Fatal("eq2 should succeed after resolving collision chain")
+			}
+
+			// Verify both slots are occupied.
+			if bd.getSlot(10).coeffRow.isZero() {
+				t.Error("slot 10 should be occupied")
+			}
+			if bd.getSlot(11).coeffRow.isZero() {
+				t.Error("slot 11 should be occupied")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ADD — w=128 specific tests
+// =============================================================================
+
+func TestAdd_128BitCoefficients(t *testing.T) {
+	// Test with coefficients that span both lo and hi halves of uint128.
+	for _, fcao := range []bool{true, false} {
+		name := fmt.Sprintf("fcao=%v", fcao)
+		t.Run(name, func(t *testing.T) {
+			bd := newStandardBander(200, 128, fcao)
+
+			// Coefficient with bits in both lo and hi.
+			eq1 := hashResult{
+				start:    5,
+				coeffRow: uint128{hi: 0xABCD, lo: 0x1},
+				result:   10,
+			}
+
+			if !bd.Add(eq1) {
+				t.Fatal("128-bit coefficient Add failed")
+			}
+
+			// Verify the slot at the pivot column is occupied.
+			if bd.getSlot(5).coeffRow.isZero() {
+				t.Error("slot 5 should be occupied")
+			}
+		})
+	}
+}
+
+func TestAdd_128BitCollisionInHiHalf(t *testing.T) {
+	// Force a collision where the pivot resolves into the hi half
+	// (TrailingZeros must cross the 64-bit boundary).
+	bd := newStandardBander(200, 128, true)
+
+	// eq1: pivot at col 5 (bit 0 = 1, start=5).
+	eq1 := hashResult{
+		start:    5,
+		coeffRow: uint128{hi: 0, lo: 1},
+		result:   3,
+	}
+	// eq2: same start, coeff has bit 0=1 and a bit in hi.
+	// XOR with eq1: lo becomes 0, hi retains the set bit.
+	// This forces the pivot into the hi half (offset ≥ 64).
+	eq2 := hashResult{
+		start:    5,
+		coeffRow: uint128{hi: 1, lo: 1},
+		result:   7,
+	}
+
+	if !bd.Add(eq1) {
+		t.Fatal("eq1 failed")
+	}
+	// eq2 XOR eq1: coeff = {hi:1, lo:0}. TrailingZeros = 64.
+	// Pivot at col 5 + 64 = 69. Should succeed (slot 69 is empty).
+	if !bd.Add(eq2) {
+		t.Fatal("eq2 should succeed (pivot at col 69 in hi half)")
+	}
+	if bd.getSlot(69).coeffRow.isZero() {
+		t.Error("slot 69 should be occupied after hi-half pivot resolution")
+	}
+}
+
+// =============================================================================
+// CROSS-VALIDATION: Add vs slowAdd
+// =============================================================================
+
+func TestAdd_MatchesSlowAdd(t *testing.T) {
+	// Verify that the optimised Add() produces the exact same outcome
+	// (success/failure) and the exact same slot contents as slowAdd()
+	// for a large number of keys across all 6 configurations.
+	//
+	// This catches any divergence introduced by the firstCoeffAlwaysOne
+	// fast path.
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				numStarts := uint32(10000)
+				numSlots := numStarts + w - 1
+				h := newTestHasherForBander(w, numStarts, fcao)
+				h.setOrdinalSeed(0)
+
+				const numKeys = 5000
+				hashes := precomputedHashResults(h, numKeys)
+
+				// Run Add on one bander, slowAdd on another.
+				bdFast := newStandardBander(numSlots, w, fcao)
+				bdSlow := newStandardBander(numSlots, w, fcao)
+
+				for i, hr := range hashes {
+					gotFast := bdFast.Add(hr)
+					gotSlow := bdSlow.slowAdd(hr)
+
+					if gotFast != gotSlow {
+						t.Fatalf("key %d: Add()=%v, slowAdd()=%v (start=%d)",
+							i, gotFast, gotSlow, hr.start)
+					}
+				}
+
+				// Verify all slots are identical.
+				for i := uint32(0); i < numSlots; i++ {
+					sf := bdFast.getSlot(i)
+					ss := bdSlow.getSlot(i)
+					if sf.coeffRow != ss.coeffRow || sf.result != ss.result {
+						t.Fatalf("slot %d differs: fast={coeff:%+v, r:%d} slow={coeff:%+v, r:%d}",
+							i, sf.coeffRow, sf.result, ss.coeffRow, ss.result)
+					}
+				}
+			})
+		}
+	}
+}
+
+// =============================================================================
+// ADD RANGE — batched insertion with prefetching
+// =============================================================================
+
+func TestAddRange_MatchesAdd(t *testing.T) {
+	// Verify that AddRange produces the exact same slot state as calling
+	// Add() in a loop for the same inputs.
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				numStarts := uint32(10000)
+				numSlots := numStarts + w - 1
+				h := newTestHasherForBander(w, numStarts, fcao)
+				h.setOrdinalSeed(0)
+
+				const numKeys = 5000
+				hashes := precomputedHashResults(h, numKeys)
+
+				// Run Add() in a loop.
+				bdAdd := newStandardBander(numSlots, w, fcao)
+				addOk := true
+				for _, hr := range hashes {
+					if !bdAdd.Add(hr) {
+						addOk = false
+						break
+					}
+				}
+
+				// Run AddRange() on the full batch.
+				bdRange := newStandardBander(numSlots, w, fcao)
+				rangeOk := bdRange.AddRange(hashes)
+
+				if addOk != rangeOk {
+					t.Fatalf("Add-loop=%v, AddRange=%v", addOk, rangeOk)
+				}
+
+				// All slots must be identical.
+				for i := uint32(0); i < numSlots; i++ {
+					sa := bdAdd.getSlot(i)
+					sr := bdRange.getSlot(i)
+					if sa.coeffRow != sr.coeffRow || sa.result != sr.result {
+						t.Fatalf("slot %d differs: Add={coeff:%+v, r:%d} AddRange={coeff:%+v, r:%d}",
+							i, sa.coeffRow, sa.result, sr.coeffRow, sr.result)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAddRange_MatchesSlowAddRange(t *testing.T) {
+	// Cross-validate AddRange against slowAddRange across all 6 configs.
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				numStarts := uint32(10000)
+				numSlots := numStarts + w - 1
+				h := newTestHasherForBander(w, numStarts, fcao)
+				h.setOrdinalSeed(0)
+
+				const numKeys = 5000
+				hashes := precomputedHashResults(h, numKeys)
+
+				bdFast := newStandardBander(numSlots, w, fcao)
+				bdSlow := newStandardBander(numSlots, w, fcao)
+
+				gotFast := bdFast.AddRange(hashes)
+				gotSlow := bdSlow.slowAddRange(hashes)
+
+				if gotFast != gotSlow {
+					t.Fatalf("AddRange()=%v, slowAddRange()=%v", gotFast, gotSlow)
+				}
+
+				for i := uint32(0); i < numSlots; i++ {
+					sf := bdFast.getSlot(i)
+					ss := bdSlow.getSlot(i)
+					if sf.coeffRow != ss.coeffRow || sf.result != ss.result {
+						t.Fatalf("slot %d differs: fast={coeff:%+v, r:%d} slow={coeff:%+v, r:%d}",
+							i, sf.coeffRow, sf.result, ss.coeffRow, ss.result)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAddRange_Empty(t *testing.T) {
+	bd := newStandardBander(100, 64, true)
+	if !bd.AddRange(nil) {
+		t.Error("AddRange(nil) should return true")
+	}
+	if !bd.AddRange([]hashResult{}) {
+		t.Error("AddRange(empty) should return true")
+	}
+}
+
+func TestAddRange_StopsOnFailure(t *testing.T) {
+	// Verify that AddRange returns false on failure, and that
+	// the state matches calling Add() key-by-key with the same
+	// stop-on-first-failure semantics.
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			// Tight sizing to force some failures.
+			const numKeys = 2000
+			numStarts := uint32(float64(numKeys) * 1.02)
+			numSlots := numStarts + w - 1
+			h := newStandardHasher(w, numStarts, 7, true)
+
+			// Try seeds until we find one that fails mid-batch.
+			for seed := uint32(0); seed < 100; seed++ {
+				h.setOrdinalSeed(seed)
+				hashes := precomputedHashResults(h, numKeys)
+
+				bdRange := newStandardBander(numSlots, w, true)
+				rangeOk := bdRange.AddRange(hashes)
+
+				// Replay with Add-loop using same stop-on-failure.
+				bdLoop := newStandardBander(numSlots, w, true)
+				loopOk := true
+				for _, hr := range hashes {
+					if !bdLoop.Add(hr) {
+						loopOk = false
+						break
+					}
+				}
+
+				if rangeOk != loopOk {
+					t.Fatalf("seed=%d: AddRange()=%v, Add-loop=%v", seed, rangeOk, loopOk)
+				}
+
+				// Verify identical state.
+				for i := uint32(0); i < numSlots; i++ {
+					sr := bdRange.getSlot(i)
+					sl := bdLoop.getSlot(i)
+					if sr.coeffRow != sl.coeffRow || sr.result != sl.result {
+						t.Fatalf("seed=%d slot %d differs", seed, i)
+					}
+				}
+
+				if !rangeOk {
+					t.Logf("seed=%d: AddRange correctly returned false", seed)
+					return // test passed — found a failure case
+				}
+			}
+			t.Log("all seeds succeeded (no failure case found)")
+		})
+	}
+}
+
+// =============================================================================
+// RESET
+// =============================================================================
+
+func TestReset(t *testing.T) {
+	for _, w := range []uint32{32, 64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			bd := newTestBander(w, true)
+			numStarts := uint32(10000)
+			h := newTestHasherForBander(w, numStarts, true)
+			h.setOrdinalSeed(0)
+
+			// Insert some keys.
+			for i := 0; i < 100; i++ {
+				kh := h.keyHash([]byte(fmt.Sprintf("reset_key_%d", i)))
+				hr := h.derive(kh)
+				bd.Add(hr)
+			}
+
+			// Verify at least some slots are occupied.
+			occupied := 0
+			for i := uint32(0); i < bd.getNumSlots(); i++ {
+				if !bd.getSlot(i).coeffRow.isZero() {
+					occupied++
+				}
+			}
+			if occupied == 0 {
+				t.Fatal("no slots occupied after insertions")
+			}
+
+			// Reset and verify all slots are empty.
+			bd.reset()
+			for i := uint32(0); i < bd.getNumSlots(); i++ {
+				slot := bd.getSlot(i)
+				if !slot.coeffRow.isZero() || slot.result != 0 {
+					t.Fatalf("slot[%d] not empty after reset", i)
+				}
+			}
+
+			// Re-insertion after reset should succeed.
+			kh := h.keyHash([]byte("after_reset"))
+			hr := h.derive(kh)
+			if !bd.Add(hr) {
+				t.Error("Add failed after reset")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// SEED RETRY — verifies banding can succeed after seed change
+// =============================================================================
+
+func TestAdd_SeedRetry(t *testing.T) {
+	// Load the filter heavily enough that some seeds might fail, then
+	// verify that retrying with a new seed can succeed.
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			// Tight sizing: numStarts ≈ 1.05 * numKeys.
+			const numKeys = 2000
+			numStarts := uint32(float64(numKeys) * 1.05)
+			numSlots := numStarts + w - 1
+			h := newStandardHasher(w, numStarts, 7, true)
+
+			succeeded := false
+			for seed := uint32(0); seed < 100; seed++ {
+				h.setOrdinalSeed(seed)
+				bd := newStandardBander(numSlots, w, true)
+
+				allOk := true
+				for i := 0; i < numKeys; i++ {
+					kh := h.keyHash([]byte(fmt.Sprintf("retry_key_%d", i)))
+					hr := h.derive(kh)
+					if !bd.Add(hr) {
+						allOk = false
+						break
+					}
+				}
+
+				if allOk {
+					succeeded = true
+					t.Logf("banding succeeded with seed=%d", seed)
+					break
+				}
+			}
+
+			if !succeeded {
+				t.Error("banding failed for all 100 seeds — unexpected")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// EDGE CASES
+// =============================================================================
+
+func TestAdd_SingleSlot(t *testing.T) {
+	// Minimum viable bander: numSlots = coeffBits (numStarts = 1).
+	// Only one possible start position.
+	for _, w := range []uint32{32, 64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			numSlots := w
+			bd := newStandardBander(numSlots, w, true)
+			h := newStandardHasher(w, 1, 7, true) // numStarts=1
+			h.setOrdinalSeed(0)
+
+			kh := h.keyHash([]byte("tiny"))
+			hr := h.derive(kh)
+
+			// start must be 0 (only one possible start).
+			if hr.start != 0 {
+				t.Fatalf("expected start=0 with numStarts=1, got %d", hr.start)
+			}
+
+			if !bd.Add(hr) {
+				t.Error("Add failed for single-start bander")
+			}
+		})
+	}
+}
+
+func TestAdd_HandCraftedDirectInsertion(t *testing.T) {
+	// Directly verify slot contents for a known hand-crafted equation.
+	bd := newStandardBander(100, 64, true)
+
+	hr := hashResult{
+		start:    7,
+		coeffRow: uint128{lo: 0b10110101}, // bits 0,2,4,5,7 set
+		result:   42,
+	}
+
+	if !bd.Add(hr) {
+		t.Fatal("Add failed")
+	}
+
+	// With fcao=true, pivot is at start=7. Coefficient is stored as-is
+	// (no shift needed since bit 0 is the pivot).
+	slot := bd.getSlot(7)
+	if slot.coeffRow != hr.coeffRow {
+		t.Errorf("stored coeffRow = %+v, want %+v", slot.coeffRow, hr.coeffRow)
+	}
+	if slot.result != hr.result {
+		t.Errorf("stored result = %d, want %d", slot.result, hr.result)
+	}
+}
+
+func TestAdd_HandCraftedWithShift(t *testing.T) {
+	// When firstCoeffAlwaysOne=false, the coefficient might not have
+	// bit 0 set, requiring a right-shift before storage.
+	bd := newStandardBander(100, 64, false)
+
+	hr := hashResult{
+		start:    10,
+		coeffRow: uint128{lo: 0b11000}, // bits 3 and 4 set; pivot offset = 3
+		result:   7,
+	}
+
+	if !bd.Add(hr) {
+		t.Fatal("Add failed")
+	}
+
+	// Pivot offset = 3 → absolute column = 10 + 3 = 13.
+	// Stored coeff = 0b11000 >> 3 = 0b11.
+	slot := bd.getSlot(13)
+	if slot.coeffRow.lo != 0b11 {
+		t.Errorf("stored coeffRow.lo = 0b%b, want 0b11", slot.coeffRow.lo)
+	}
+	if slot.result != 7 {
+		t.Errorf("stored result = %d, want 7", slot.result)
+	}
+}
+
+// =============================================================================
+// LARGE-SCALE STATISTICAL TESTS
+// =============================================================================
+
+func TestAdd_SuccessRate(t *testing.T) {
+	// With proper sizing (numStarts ≈ 1.02*N for w=128), the banding
+	// should succeed with high probability. Test across seeds to measure
+	// the success rate.
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			const numKeys = 5000
+			// Paper §4: overhead ratio m/n ≈ 1 + 2.3/w.
+			// Use 1.05 for safety margin.
+			numStarts := uint32(float64(numKeys) * 1.05)
+			numSlots := numStarts + w - 1
+
+			h := newStandardHasher(w, numStarts, 7, true)
+			successes := 0
+			const numTrials = 50
+
+			for seed := uint32(0); seed < numTrials; seed++ {
+				h.setOrdinalSeed(seed)
+				bd := newStandardBander(numSlots, w, true)
+
+				allOk := true
+				for i := 0; i < numKeys; i++ {
+					kh := h.keyHash([]byte(fmt.Sprintf("stat_key_%d", i)))
+					hr := h.derive(kh)
+					if !bd.Add(hr) {
+						allOk = false
+						break
+					}
+				}
+				if allOk {
+					successes++
+				}
+			}
+
+			rate := float64(successes) / float64(numTrials)
+			t.Logf("w=%d: %d/%d seeds succeeded (%.1f%%)", w, successes, numTrials, rate*100)
+
+			// With 5% overhead and w≥64, at least ~50% of seeds should work.
+			if rate < 0.3 {
+				t.Errorf("success rate %.1f%% is unexpectedly low", rate*100)
+			}
+		})
+	}
+}

--- a/uint128.go
+++ b/uint128.go
@@ -91,6 +91,22 @@ func (u uint128) bit(i uint) uint {
 	return uint((u.lo >> i) & 1)
 }
 
+// trailingZeros returns the number of trailing zero bits in the 128-bit value.
+// If u is zero, returns 128 (all bits are trailing zeros).
+//
+// Used by the banding algorithm to find the pivot offset — the lowest set bit
+// in a coefficient row determines which column is the elimination pivot.
+//
+// Performance: compiles to a single TZCNT/BSF instruction on the lo half
+// in the common case (w≤64, or w=128 when lo≠0). The hi half is only
+// touched when lo is entirely zero.
+func (u uint128) trailingZeros() uint {
+	if u.lo != 0 {
+		return uint(bits.TrailingZeros64(u.lo))
+	}
+	return 64 + uint(bits.TrailingZeros64(u.hi))
+}
+
 // putBytes serialises the uint128 into a 16-byte array in little-endian order.
 // lo occupies bytes [0..7], hi occupies bytes [8..15].
 func (u uint128) putBytes() [16]byte {

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -164,3 +164,45 @@ func TestUint128_FromBytes_PanicOnShortSlice(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// trailingZeros — find the lowest set bit position
+// ---------------------------------------------------------------------------
+
+func TestUint128_TrailingZeros(t *testing.T) {
+	cases := []struct {
+		name string
+		val  uint128
+		want uint
+	}{
+		// lo-only values (common case for w≤64)
+		{"lo_bit0", uint128{lo: 1}, 0},
+		{"lo_bit1", uint128{lo: 2}, 1},
+		{"lo_bit63", uint128{lo: 1 << 63}, 63},
+		{"lo_mixed", uint128{lo: 0x80}, 7},
+		{"lo_all_ones", uint128{lo: ^uint64(0)}, 0},
+
+		// hi-only values (lo=0, w=128 scenarios)
+		{"hi_bit0", uint128{hi: 1}, 64},
+		{"hi_bit1", uint128{hi: 2}, 65},
+		{"hi_bit63", uint128{hi: 1 << 63}, 127},
+		{"hi_mixed", uint128{hi: 0x100}, 72},
+
+		// both halves set — lo takes precedence
+		{"both_lo_wins", uint128{hi: 1, lo: 4}, 2},
+		{"both_lo_bit0", uint128{hi: ^uint64(0), lo: 1}, 0},
+
+		// zero value (edge case — should return 128)
+		{"zero", uint128{}, 128},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.val.trailingZeros()
+			if got != tc.want {
+				t.Errorf("trailingZeros({hi: 0x%016x, lo: 0x%016x}) = %d, want %d",
+					tc.val.hi, tc.val.lo, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Core Banding Module

## Summary

Implements the **Banding (Matrix Construction)** layer of the Ribbon filter — the core Gaussian elimination engine that converts hashed key equations into an upper-triangular banded matrix over GF(2).

This is the second layer in the Ribbon filter pipeline (`hash → **bander** → backsubst → query → filter`), and the hottest code path during filter construction. Every key passes through `Add()` exactly once per seed attempt.

**Paper reference:** Dillinger & Walzer, _"Ribbon filter: practically smaller than Bloom and Xor"_, 2021 — §2 (banding algorithm), §4 (firstCoeffAlwaysOne optimisation).

## What's included

### `bander.go` (752 lines)

- **`bander` interface** — `Add`, `AddRange`, `reset`, `getSlot`, `getNumSlots`
- **`standardBander` struct** — SoA (Struct-of-Arrays) memory layout with width-specialised inner loops:
  - `coeffLo []uint64` — lower 64 bits of coefficient per slot
  - `coeffHi []uint64` — upper 64 bits (w=128 only; `nil` for w≤64)
  - `result []uint8` — r-bit fingerprint per slot
- **`Add(hr hashResult) bool`** — single-key on-the-fly Gaussian elimination, dispatches to:
  - `addW64()` — pure `uint64` path for w≤64 (TZCNT → LSR → EOR, ~10 ARM64 instructions/step)
  - `addW128()` — separate lo/hi `uint64` ops for w=128, avoids generic `uint128.rsh()` 4-branch ladder
- **`AddRange(hrs []hashResult) bool`** — batched insertion with software-pipelined prefetching (prefetches `coeffs[key[i+1].start]` while processing `key[i]`), dispatches to:
  - `addRangeW64()` — prefetching variant for w≤64
  - `addRangeW128()` — prefetching variant for w=128
- **`slowAdd()` / `slowAddRange()`** — unoptimised reference implementations (textbook algorithm, no width specialisation, no prefetch) used as correctness oracles in cross-validation tests
- **`reset()`** — zeroes all arrays via `clear()` (compiles to `memset`)
- **`getSlot()`** — reconstructs `bandingSlot` from SoA arrays for back-substitution

### `uint128.go` addition

- **`trailingZeros()`** method on `uint128` — returns the position of the lowest set bit (0–128). Inline cost 19; compiles to `TZCNT` on ARM64. Used by `slowAdd()`.

### `bander_test.go` (804 lines, 21 test functions, 76+ subtests)

| Test | What it verifies |
|------|-----------------|
| `TestNewStandardBander` | Constructor: slot count, SoA array lengths, zero-initialisation (6 configs) |
| `TestNewStandardBander_InvalidCoeffBits` | Panics on invalid widths (0, 16, 48, 96, 256) |
| `TestAdd_SingleInsertion` | Single key always succeeds (6 configs) |
| `TestAdd_MultipleNonConflicting` | 500 keys into 10K slots — near-100% success rate |
| `TestAdd_RedundantEquation` | Same equation twice → `false` (c=0, r=0) |
| `TestAdd_ContradictoryEquation` | Same coeff, different result → `false` (c=0, r≠0) |
| `TestAdd_MultiStepCollisionChain` | Multi-step XOR chain → linear dependence detected |
| `TestAdd_ChainResolves` | Collision chain that resolves to a different empty slot |
| `TestAdd_128BitCoefficients` | Coefficients spanning both lo and hi halves |
| `TestAdd_128BitCollisionInHiHalf` | Pivot resolution crossing the 64-bit boundary (offset ≥ 64) |
| `TestAdd_MatchesSlowAdd` | **Cross-validation**: `Add()` vs `slowAdd()` — 5000 keys × 6 configs, slot-by-slot comparison |
| `TestAddRange_MatchesAdd` | **Cross-validation**: `AddRange()` vs `Add()`-loop — 5000 keys × 6 configs |
| `TestAddRange_MatchesSlowAddRange` | **Cross-validation**: `AddRange()` vs `slowAddRange()` — 5000 keys × 6 configs |
| `TestAddRange_Empty` | `nil` and empty slice both return `true` |
| `TestAddRange_StopsOnFailure` | Returns `false` on first failure, state matches `Add()`-loop |
| `TestReset` | All slots zero after reset; re-insertion succeeds |
| `TestAdd_SeedRetry` | Tight sizing — retrying with new seeds eventually succeeds |
| `TestAdd_SingleSlot` | Minimum viable bander (numSlots = w, numStarts = 1) |
| `TestAdd_HandCraftedDirectInsertion` | Verifies exact stored coeffRow and result for known input |
| `TestAdd_HandCraftedWithShift` | fcao=false: verifies right-shift before storage |
| `TestAdd_SuccessRate` | Statistical: 50 seeds × 5000 keys, success rate > 30% |

### `bander_bench_test.go` (320 lines, 5 benchmark suites)

| Benchmark | What it measures |
|-----------|-----------------|
| `BenchmarkAdd` | Per-key amortised cost (6 configs: 3 widths × 2 fcao) |
| `BenchmarkAddHighLoad` | Collision chain impact at ~10% overhead (w=64, w=128) |
| `BenchmarkBandingPassThroughput` | Full 10K-key pass throughput (w=64, w=128) |
| `BenchmarkBandingPassComparison` | **Add-loop vs AddRange** at 10K and 100K keys (8 configs) |
| `BenchmarkReset` | Reset cost at 1K, 10K, 100K slots |

## Design decisions

### SoA layout (not AoS)

An earlier iteration used `[]bandingSlot` (AoS, 24 bytes/slot with 7 bytes padding). Profiling showed:
- Only ~2.67 slots per 64-byte cache line
- For w≤64, the `uint128.hi` field is always 0 — pure overhead in every operation
- The generic `uint128.rsh()` generated ~20 ARM64 instructions with 4 branches per call

The SoA layout (`coeffLo []uint64` + `coeffHi []uint64` + `result []uint8`) fixes all three:
- 8 `uint64` coefficients per cache line for w≤64
- `coeffHi` is `nil` for w≤64 — zero memory, zero operations
- Width-specialised `addW64()` uses native `uint64` shifts — no `uint128` overhead

### Software-pipelined prefetching in `AddRange`

Matches RocksDB's `BandingAddRange` (ribbon_alg.h). While processing `key[i]`, a dummy load `_ = coeffs[key[i+1].start]` pulls the next key's cache line into L1. The Go compiler cannot eliminate this because slice indexing may panic (observable side effect).

### Occupancy tracking via zero-check (no separate bitmap)

A slot is occupied iff `coeffRow ≠ 0`. This works because:
1. The hasher guarantees non-zero coefficient rows
2. After right-shifting to the pivot, bit 0 is always 1
3. A zero coefficient during elimination means linear dependence → immediate failure, nothing stored

## Benchmark results

**Apple M3 Pro, Go 1.25, ARM64**

### Per-key Add (low load)

| Width | fcao | ns/op | keys/sec |
|-------|------|-------|----------|
| w=32 | true | 4.99 | ~200M |
| w=64 | true | 4.99 | ~200M |
| w=128 | true | 6.67 | ~150M |
| w=32 | false | 5.71 | ~175M |
| w=64 | false | 5.73 | ~175M |
| w=128 | false | 7.33 | ~137M |

### Add-loop vs AddRange (full banding pass)

| Keys | Width | Add-loop | AddRange | Improvement |
|------|-------|----------|----------|-------------|
| 10K | w=64 | 71.6 µs (~140M keys/sec) | 52.7 µs (~190M keys/sec) | **−26%** |
| 10K | w=128 | 110.2 µs (~90.7M keys/sec) | 94.6 µs (~106M keys/sec) | **−14%** |
| 100K | w=64 | 1.84 ms (~54.5M keys/sec) | 1.47 ms (~68.2M keys/sec) | **−20%** |
| 100K | w=128 | 2.18 ms (~45.8M keys/sec) | 1.95 ms (~51.2M keys/sec) | **−11%** |

### All benchmarks: zero allocations, zero heap escapes in hot paths.

## Test results

```
162 subtests — all PASS
0 failures
0 allocations in hot paths
```

## Dependencies

- Uses `uint128` and `hashResult` types from the existing `hash.go` / `uint128.go` modules (PR #1).
- No new external dependencies.
