### PR TITLE
core library API

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,448 @@
+package ribbon
+
+import "math"
+
+// =============================================================================
+// BUILD — internal filter construction with seed-retry loop
+// =============================================================================
+
+// defaultConfig returns the recommended configuration for general use.
+//
+// It selects w=128 (most compact), r=7 (FPR ≈ 0.78%), firstCoeffAlwaysOne
+// (fastest construction), and lets the builder compute the optimal
+// overhead ratio and seed budget automatically.
+//
+// Paper §4: "w=128 seems to be closest to a generally good choice."
+func defaultConfig() Config {
+	return Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+	}
+}
+
+// buildFilter constructs a Ribbon filter from raw byte-slice keys.
+//
+// Phase 1 (once): each key is hashed with XXH3 to a 64-bit stored hash.
+// Phase 2 (per seed attempt): stored hashes are remixed with the current
+// seed and fed to the banding algorithm. On success, back-substitution
+// produces the solution vector which is packaged into a filter.
+//
+// Paper §2: "We hash each key once (Phase 1). For each seed attempt,
+// we derive (start, coefficients, result) triples (Phase 2) and
+// perform on-the-fly Gaussian elimination."
+//
+// Keys must be unique: duplicate keys produce identical (start, coeff,
+// result) triples regardless of seed, causing guaranteed linear
+// dependence. If duplicates may be present, the caller should
+// de-duplicate before calling buildFilter.
+//
+// Returns ErrConstructionFailed if banding fails for all seeds.
+//
+// [RocksDB: Standard128RibbonBitsBuilder::Finish in filter_policy.cc]
+func buildFilter(keys [][]byte, cfg Config) (*filter, error) {
+	validateConfig(cfg)
+	cfg = normalizeConfig(cfg)
+
+	numKeys := len(keys)
+	if numKeys == 0 {
+		return emptyFilter(cfg), nil
+	}
+
+	// Phase 1: hash all keys once with XXH3.
+	// The stored hashes are reused across all seed attempts, amortising
+	// the cost of the expensive XXH3 computation.
+	h := newStandardHasher(cfg.CoeffBits, 0, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+	hashes := make([]uint64, numKeys)
+	for i, key := range keys {
+		hashes[i] = h.keyHash(key)
+	}
+
+	return buildCore(hashes, cfg)
+}
+
+// buildFromHashes constructs a Ribbon filter from pre-computed 64-bit
+// key hashes.
+//
+// The hashes must have been produced by the same Phase 1 hash function
+// used internally (XXH3). This is useful for applications that maintain
+// their own hash cache or use pre-hashed pipelines.
+//
+// Hashes must be unique: duplicate hashes produce identical equations
+// regardless of seed, causing guaranteed linear dependence.
+//
+// Returns ErrConstructionFailed if banding fails for all seeds.
+func buildFromHashes(hashes []uint64, cfg Config) (*filter, error) {
+	validateConfig(cfg)
+	cfg = normalizeConfig(cfg)
+
+	if len(hashes) == 0 {
+		return emptyFilter(cfg), nil
+	}
+
+	return buildCore(hashes, cfg)
+}
+
+// =============================================================================
+// INTERNAL — construction core and helpers
+// =============================================================================
+
+// buildCore implements the seed-retry loop that orchestrates the hasher,
+// bander, and solver to produce a filter.
+//
+// Algorithm (paper §2):
+//  1. Compute numStarts and numSlots from numKeys and coeffBits.
+//  2. Create a standardHasher and standardBander.
+//  3. For each seed ordinal 0..MaxSeeds-1:
+//     a. Set the hasher's seed.
+//     b. Derive (start, coeffRow, result) for every stored hash.
+//     c. Reset the bander and attempt AddRange.
+//     d. If successful, call backSubstitute and return the filter.
+//  4. If all seeds fail, return ErrConstructionFailed.
+//
+// Memory strategy:
+//   - The []hashResult buffer is allocated once and reused across retries.
+//   - The bander is allocated once and reset() between retries (clear()
+//     compiles to optimised memset, avoiding per-element zeroing).
+//   - Only the final solution allocates new memory (one []uint8).
+//
+// [RocksDB: BandingAdd retry loop in StandardBanding::ResetAndFindSeedToSolve]
+func buildCore(hashes []uint64, cfg Config) (*filter, error) {
+	numKeys := len(hashes)
+
+	// Compute sizing.
+	// The overhead ratio grows logarithmically with n (not a fixed constant).
+	// RocksDB ribbon_config.cc uses empirically-derived lookup tables for
+	// small n and a formula (baseFactor + log2(n) * factorPerPow2) for
+	// large n. The overhead for ~5% per-seed failure probability is:
+	//   w=128: ~1.04 at n=1K, ~1.05 at n=1M
+	//   w=64:  ~1.05 at n=1K, ~1.12 at n=1M
+	//   w=32:  ~1.11 at n=1K, ~1.30 at n=1M
+	// numSlots: total columns in the banding matrix.
+	// numStarts: valid start positions (= numSlots - w + 1).
+	numSlots := computeNumSlots(numKeys, cfg.CoeffBits)
+	numStarts := numSlots - cfg.CoeffBits + 1
+
+	// Create the hasher (concrete *standardHasher for devirtualisation).
+	h := newStandardHasher(cfg.CoeffBits, numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+
+	// Create the bander (allocated once, reset between retries).
+	bd := newStandardBander(numSlots, cfg.CoeffBits, cfg.FirstCoeffAlwaysOne)
+
+	// Pre-allocate the hashResult buffer (reused across all seed attempts).
+	// Each hashResult is 24 bytes; for 100K keys this is ~2.4 MB — acceptable
+	// for a one-time construction cost, and AddRange's software-pipelined
+	// prefetching more than pays for it on large filters.
+	hrs := make([]hashResult, numKeys)
+
+	// Seed-retry loop.
+	for seed := uint32(0); seed < cfg.MaxSeeds; seed++ {
+		h.setOrdinalSeed(seed)
+
+		// Phase 2: derive (start, coeffRow, result) for all keys.
+		for i, kh := range hashes {
+			hrs[i] = h.derive(kh)
+		}
+
+		// Reset the bander's slot arrays for this attempt.
+		bd.reset()
+
+		// Attempt banding: on-the-fly Gaussian elimination over GF(2).
+		if bd.AddRange(hrs) {
+			// Success! Back-substitute to compute the solution vector S.
+			sol := backSubstitute(bd, cfg.ResultBits)
+			return newFilterFromSolution(sol, h, seed, numSlots), nil
+		}
+		// Banding failed (linear dependence). Try next seed.
+	}
+
+	return nil, ErrConstructionFailed
+}
+
+// validateConfig panics on invalid configuration values.
+// These are programmer errors (wrong constants), not runtime failures.
+func validateConfig(cfg Config) {
+	switch cfg.CoeffBits {
+	case 32, 64, 128:
+		// valid
+	default:
+		panic("ribbon: Config.CoeffBits must be 32, 64, or 128")
+	}
+	if cfg.ResultBits == 0 || cfg.ResultBits > 8 {
+		panic("ribbon: Config.ResultBits must be in [1, 8]")
+	}
+}
+
+// normalizeConfig fills in zero-valued optional fields with sensible defaults.
+func normalizeConfig(cfg Config) Config {
+	if cfg.MaxSeeds == 0 {
+		cfg.MaxSeeds = 256
+	}
+	return cfg
+}
+
+// =============================================================================
+// SLOT COMPUTATION — RocksDB-style dynamic overhead ratio
+// =============================================================================
+
+// bandingConfigData holds empirically-derived parameters for computing the
+// number of slots from the number of keys.
+//
+// Unlike the simplified formula m/n ≈ 1 + 2.3/w (which is the theoretical
+// minimum for ~50% per-seed success), the ACTUAL required overhead ratio
+// grows logarithmically with n. For large n, this growth is significant:
+//   - w=64  at n=10K needs ~1.06× but at n=100M needs ~1.14×
+//   - w=128 at n=10K needs ~1.03× but at n=100M needs ~1.05×
+//
+// RocksDB solves this with empirically-derived lookup tables (from the
+// FindOccupancy test) for 2^0..2^17 slots, and a linear extrapolation
+// formula for larger slot counts:
+//
+//	factor = baseFactor + log2(numSlots) × factorPerPow2
+//
+// where factor = numSlots / numKeysAdded.
+//
+// The data below uses kOneIn20 construction failure chance (~5% per seed),
+// without smash. This matches the RocksDB default for standard filters.
+//
+// [RocksDB: BandingConfigHelperData in ribbon_config.cc]
+type bandingConfigData struct {
+	// knownToAdd[i] = max keys that can be banded into 2^i slots with
+	// ~5% per-seed failure probability. Zero means unsupported.
+	knownToAdd [18]float64
+
+	// factorPerPow2: how much the overhead factor increases per doubling
+	// of the slot count. Used for extrapolation beyond the lookup table.
+	factorPerPow2 float64
+
+	// baseFactor: precomputed from the lookup table as:
+	//   baseFactor = (2^17 / knownToAdd[17]) - 17 * factorPerPow2
+	baseFactor float64
+}
+
+// getNumToAddForPow2 returns how many keys can be banded into 2^log2Slots
+// slots with ~5% per-seed failure probability.
+func (d *bandingConfigData) getNumToAddForPow2(log2Slots uint32) float64 {
+	if log2Slots < 18 {
+		if v := d.knownToAdd[log2Slots]; v > 0 {
+			return v
+		}
+	}
+	// Formula for large values or unsupported small values.
+	factor := d.baseFactor + float64(log2Slots)*d.factorPerPow2
+	if factor < 1.0 {
+		factor = 1.0
+	}
+	return float64(uint64(1)<<log2Slots) / factor
+}
+
+// Empirical data from RocksDB's FindOccupancy test (ribbon_config.cc).
+// kOneIn20, kCoeffBits=128, smash=false.
+var configData128 = func() bandingConfigData {
+	known := [18]float64{
+		0, 0, 0, 0, 0, 0, 0, 0, // 2^0..2^7: unsupported
+		248.851, // 2^8  = 256 slots
+		499.532, // 2^9  = 512
+		1001.26, // 2^10 = 1024
+		2003.97, // 2^11 = 2048
+		4005.59, // 2^12 = 4096
+		8000.39, // 2^13 = 8192
+		15966.6, // 2^14 = 16384
+		31828.1, // 2^15 = 32768
+		63447.3, // 2^16 = 65536
+		126506,  // 2^17 = 131072
+	}
+	const fpp = 0.0038
+	finalFactor := float64(uint32(1)<<17) / known[17]
+	return bandingConfigData{
+		knownToAdd:    known,
+		factorPerPow2: fpp,
+		baseFactor:    finalFactor - 17*fpp,
+	}
+}()
+
+// kOneIn20, kCoeffBits=64, smash=false.
+var configData64 = func() bandingConfigData {
+	known := [18]float64{
+		0, 0, 0, 0, 0, 0, 0, // 2^0..2^6: unsupported
+		120.659, // 2^7  = 128 slots
+		243.346, // 2^8  = 256
+		488.168, // 2^9  = 512
+		976.373, // 2^10 = 1024
+		1948.86, // 2^11 = 2048
+		3875.85, // 2^12 = 4096
+		7704.97, // 2^13 = 8192
+		15312.4, // 2^14 = 16384
+		30395.1, // 2^15 = 32768
+		60321.8, // 2^16 = 65536
+		119813,  // 2^17 = 131072
+	}
+	const fpp = 0.0083
+	finalFactor := float64(uint32(1)<<17) / known[17]
+	return bandingConfigData{
+		knownToAdd:    known,
+		factorPerPow2: fpp,
+		baseFactor:    finalFactor - 17*fpp,
+	}
+}()
+
+// w=32: RocksDB does not support this width. We extrapolate from the
+// pattern that factorPerPow2 roughly doubles as w halves:
+//
+//	w=128: 0.0038, w=64: 0.0083, w=32: ~0.019 (extrapolated)
+//
+// baseFactor similarly decreases: 0.9715 → 0.9528 → ~0.93.
+// No lookup table — formula-only with conservative estimates.
+var configData32 = bandingConfigData{
+	knownToAdd:    [18]float64{}, // no empirical data
+	factorPerPow2: 0.0200,        // conservative: ~2.4× the w=64 rate
+	baseFactor:    0.9100,        // conservative: ~0.04 below w=64
+}
+
+// computeNumSlots determines the total number of banding matrix columns
+// (slots) for the given number of keys and ribbon width.
+//
+// This implements the RocksDB-style dynamic overhead ratio, where the
+// overhead grows logarithmically with n. For small n, empirically-derived
+// lookup tables provide exact values. For large n, a linear extrapolation
+// formula is used.
+//
+// The returned numSlots includes the extra (w-1) columns that form the
+// "tail" of the banding matrix: numSlots = numStarts + coeffBits - 1.
+//
+// [RocksDB: BandingConfigHelper1MaybeSupported::GetNumSlots in ribbon_config.cc]
+func computeNumSlots(numKeys int, coeffBits uint32) uint32 {
+	if numKeys == 0 {
+		return 0
+	}
+
+	var d *bandingConfigData
+	switch coeffBits {
+	case 128:
+		d = &configData128
+	case 64:
+		d = &configData64
+	case 32:
+		d = &configData32
+	default:
+		panic("ribbon: unsupported coeffBits for slot computation")
+	}
+
+	numToAdd := float64(numKeys)
+	log2NumToAdd := math.Log(numToAdd) * 1.4426950409 // 1/ln(2)
+	approxLog2Slots := uint32(log2NumToAdd + 0.5)
+	if approxLog2Slots > 32 {
+		approxLog2Slots = 32
+	}
+
+	lowerNumToAdd := d.getNumToAddForPow2(approxLog2Slots)
+
+	var upperNumToAdd float64
+	if approxLog2Slots == 0 || lowerNumToAdd == 0 {
+		// Return minimum non-zero slots (not using smash mode).
+		return coeffBits * 2
+	}
+
+	if numToAdd < lowerNumToAdd {
+		upperNumToAdd = lowerNumToAdd
+		approxLog2Slots--
+		lowerNumToAdd = d.getNumToAddForPow2(approxLog2Slots)
+		if lowerNumToAdd == 0 {
+			return coeffBits * 2
+		}
+	} else {
+		upperNumToAdd = d.getNumToAddForPow2(approxLog2Slots + 1)
+	}
+
+	upperPortion := (numToAdd - lowerNumToAdd) / (upperNumToAdd - lowerNumToAdd)
+	lowerNumSlots := float64(uint64(1) << approxLog2Slots)
+
+	// Interpolation, round up (matching RocksDB).
+	numSlots := uint32(upperPortion*lowerNumSlots + lowerNumSlots + 0.999999999)
+
+	// Ensure numSlots is large enough for at least 1 start position
+	// plus the (w-1) tail: numStarts = numSlots - coeffBits + 1 >= 1.
+	minSlots := coeffBits * 2
+	if numSlots < minSlots {
+		numSlots = minSlots
+	}
+
+	return numSlots
+}
+
+// computeNumStarts derives the number of valid start positions from the
+// number of keys and the overhead ratio.
+//
+//	numStarts = ceil(numKeys * overheadRatio)
+//
+// Guaranteed ≥ 1 for non-empty key sets.
+func computeNumStarts(numKeys int, overheadRatio float64) uint32 {
+	ns := uint32(math.Ceil(float64(numKeys) * overheadRatio))
+	if ns < 1 {
+		ns = 1
+	}
+	return ns
+}
+
+// emptyFilter returns a filter that always returns false for contains.
+// Used when buildFilter is called with zero keys.
+func emptyFilter(cfg Config) *filter {
+	return &filter{
+		hasher: *newStandardHasher(cfg.CoeffBits, 0, cfg.ResultBits, cfg.FirstCoeffAlwaysOne),
+	}
+}
+
+// buildCoreWithOverride is an unexported variant of buildCore that accepts
+// an explicit overhead ratio, bypassing the automatic derivation from w.
+// Used only by tests that need to force pathological ratios (e.g. 1.001)
+// to exercise the retry loop and error paths.
+func buildCoreWithOverride(hashes []uint64, cfg Config, overheadRatio float64) (*filter, error) {
+	numKeys := len(hashes)
+	numStarts := computeNumStarts(numKeys, overheadRatio)
+	numSlots := numStarts + cfg.CoeffBits - 1
+
+	h := newStandardHasher(cfg.CoeffBits, numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+	bd := newStandardBander(numSlots, cfg.CoeffBits, cfg.FirstCoeffAlwaysOne)
+	hrs := make([]hashResult, numKeys)
+
+	for seed := uint32(0); seed < cfg.MaxSeeds; seed++ {
+		h.setOrdinalSeed(seed)
+		for i, kh := range hashes {
+			hrs[i] = h.derive(kh)
+		}
+		bd.reset()
+		if bd.AddRange(hrs) {
+			sol := backSubstitute(bd, cfg.ResultBits)
+			return newFilterFromSolution(sol, h, seed, numSlots), nil
+		}
+	}
+	return nil, ErrConstructionFailed
+}
+
+// newFilterFromSolution packages a solution into a filter, padding the
+// data array for bounds-check elimination in the contains hot path.
+//
+// The solution data from backSubstitute has length numSlots + w (where w
+// is the solver's detected width — which may be 64 for w=32, see note
+// in backSubstitute). We re-allocate with numSlots + 128 bytes of
+// capacity so that contains can use a single `_ = data[127]` BCE proof
+// for all ribbon widths:
+//
+//	For w=32:  max start = numSlots-32,  data[start:] has len ≥ 160  → data[127] ✓
+//	For w=64:  max start = numSlots-64,  data[start:] has len ≥ 192  → data[127] ✓
+//	For w=128: max start = numSlots-128, data[start:] has len ≥ 256  → data[127] ✓
+//
+// The extra padding bytes are always zero, matching the semantics of
+// empty (unoccupied) solution slots.
+func newFilterFromSolution(sol *solution, h *standardHasher, seed uint32, numSlots uint32) *filter {
+	paddedLen := int(numSlots) + 128
+	data := make([]uint8, paddedLen)
+	copy(data, sol.data)
+
+	return &filter{
+		data:     data,
+		hasher:   *h, // copy by value for cache locality
+		seed:     seed,
+		numSlots: numSlots,
+	}
+}

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,179 @@
+package ribbon
+
+import "math/bits"
+
+// =============================================================================
+// FILTER — the read-only, thread-safe Ribbon filter
+// =============================================================================
+
+// filter is the immutable, query-ready Ribbon filter structure.
+//
+// After construction (via buildFilter or buildFromHashes), the filter
+// supports fast, zero-allocation membership queries through contains and
+// containsHash.
+//
+// Paper §2 & §3: the filter stores the solution vector S computed by
+// back-substitution, plus the hash seed and configuration needed to
+// reproduce the (start, coeffRow, result) triple for any key. A query
+// hashes the key, derives the triple, computes the GF(2) dot product of
+// the coefficient row against the solution window, and compares the
+// computed result to the expected fingerprint.
+//
+// Memory layout:
+//
+// The solution vector is stored as one uint8 per slot (row-major), padded
+// to numSlots + 128 bytes. The extra 128 bytes ensure that containsHash
+// can use a single bounds-check elimination proof (`_ = data[127]`) for
+// all ribbon widths (w = 32, 64, 128), avoiding per-iteration bounds
+// checks in the dot-product loop.
+//
+// The standardHasher is stored by value (not pointer) so that its ~96
+// bytes of pre-computed masks sit adjacent to the slice header in memory,
+// improving cache locality on the hot query path.
+//
+// Thread safety: filter is immutable after construction. contains and
+// containsHash may be called concurrently from multiple goroutines
+// without synchronisation.
+//
+// [RocksDB: InMemSimpleSolution + SimpleFilterQuery in ribbon_impl.h / ribbon_alg.h]
+type filter struct {
+	// data holds the solution vector: one r-bit result row (uint8) per
+	// slot, padded to numSlots + 128 bytes for bounds-check elimination.
+	// Padding bytes are zero, matching empty (unoccupied) solution slots.
+	data []uint8
+
+	// hasher is the concrete standardHasher configured with the successful
+	// seed and all per-width pre-computed masks (coeffLoMask, coeffHiMask,
+	// coeffXor, coeffOrMask, resultMask). Stored by value for two reasons:
+	//   (a) cache locality: the hasher's fields are in the same allocation
+	//       as the filter, likely on the same cache line.
+	//   (b) devirtualisation: calling derive() on a concrete struct (not an
+	//       interface) allows the compiler to inline the method (cost 67 <
+	//       budget 80), eliminating call overhead on the hot query path.
+	hasher standardHasher
+
+	// seed is the ordinal seed that succeeded during construction.
+	// Stored for serialisation: the filter can be reconstructed from
+	// (data[:numSlots], seed, config). Not used in the query path.
+	seed uint32
+
+	// numSlots is the total number of slots in the solution vector.
+	// Equal to numStarts + coeffBits - 1. Used by accessors and
+	// serialisation; not accessed in the query hot path.
+	numSlots uint32
+}
+
+// =============================================================================
+// CONTAINS — the membership query hot path
+// =============================================================================
+
+// contains tests whether key is a member of the set used to build this
+// filter. Returns true if the key is probably in the set (with false-positive
+// probability ≈ 2^(-r)), or false if the key is definitely not in the set.
+//
+// Paper §2: "To query whether x is a member, compute (s(x), c(x), r(x))
+// and check whether c(x) · S[s(x)..s(x)+w-1] = r(x) over GF(2)."
+//
+// Performance: this method is the most frequently called code in the
+// entire library. It is designed for:
+//   - Zero heap allocations: hashResult is a value type (stack-allocated),
+//     and derive() is inlineable (cost 67 < budget 80).
+//   - Minimal branching: the only branch is the numStarts==0 guard
+//     (always-false for non-empty filters, perfectly predicted).
+//   - Bounds-check elimination: a single `_ = data[127]` proof at the
+//     top of containsHash eliminates all per-iteration bounds checks.
+//   - Skip-zero iteration: the dot-product loop iterates only over set
+//     bits using TZCNT + clear-lowest-bit, halving iteration count vs
+//     a naive 0..w loop (~w/2 iterations for random coefficient rows).
+//
+// [RocksDB: SimpleFilterQuery in ribbon_alg.h]
+func (f *filter) contains(key []byte) bool {
+	if f.hasher.numStarts == 0 {
+		return false
+	}
+	h := f.hasher.keyHash(key)
+	return f.containsHash(h)
+}
+
+// containsHash is the inlined query core. It performs the full Phase 2
+// derive + GF(2) dot product in one tight sequence.
+//
+// Algorithm:
+//
+//  1. derive(h) → (start, coeffRow, expectedResult)
+//     derive() is inlineable (cost 67) and computes:
+//     - rehash: (h ^ rawSeed) * kRehashFactor
+//     - start:  fastRange64(rehashed, numStarts)   [high bits]
+//     - coeff:  multiply → mask/xor/or             [branchless]
+//     - result: multiply → bswap → mask            [byte-swapped]
+//
+//  2. Dot product: iterate over set bits in coeffRow, XOR the
+//     corresponding solution bytes into a running result.
+//     Uses TrailingZeros64 (TZCNT/BSF) + clear-lowest-bit (BLSR)
+//     to visit only the ~w/2 set bits in a random coefficient row.
+//
+//  3. Compare: return (computed == expected).
+//
+// Bounds-check elimination (BCE):
+//
+// A single `_ = data[127]` proof guarantees all per-iteration accesses
+// are in-bounds. The filter's data is padded to numSlots + 128 bytes,
+// and the maximum start is numStarts - 1 = numSlots - w, so
+// data[start:] has length >= w + 128 >= 160 for all w in {32, 64, 128}.
+//
+// The `& 63` masks on TrailingZeros64 results provide a compile-time
+// proof that lo-loop indices are in [0, 63] and hi-loop indices are
+// in [64, 127], both <= 127, eliminating bounds checks entirely.
+//
+// Returns false for empty filters (numStarts == 0).
+//
+// [RocksDB: SimpleQueryHelper in ribbon_alg.h]
+func (f *filter) containsHash(h uint64) bool {
+	if f.hasher.numStarts == 0 {
+		return false
+	}
+
+	hr := f.hasher.derive(h)
+
+	// Slice the solution window starting at the key's start position.
+	// The BCE proof ensures data[0..127] are all in-bounds.
+	data := f.data[hr.start:]
+	_ = data[127] // BCE proof: all subsequent accesses are within [0, 127].
+
+	// GF(2) dot product: XOR solution bytes at each set coefficient bit.
+	var result uint8
+
+	// Process the lower 64 bits of the coefficient row (positions 0..63).
+	lo := hr.coeffRow.lo
+	for lo != 0 {
+		result ^= data[bits.TrailingZeros64(lo)&63]
+		lo &= lo - 1 // clear lowest set bit (BLSR)
+	}
+
+	// Process the upper 64 bits (positions 64..127).
+	// For w <= 64, coeffRow.hi is always 0, making this a zero-iteration loop.
+	hi := hr.coeffRow.hi
+	for hi != 0 {
+		result ^= data[64+bits.TrailingZeros64(hi)&63]
+		hi &= hi - 1
+	}
+
+	return result == hr.result
+}
+
+// =============================================================================
+// HELPERS — filter metadata for inspection and testing
+// =============================================================================
+
+// fpRate returns the theoretical false-positive rate: 2^(-r).
+//
+// Paper §3: "the false-positive probability is 2^(-r), where r is the
+// number of result bits."
+//
+// Returns 0.0 for empty filters (no false positives when there are no keys).
+func (f *filter) fpRate() float64 {
+	if f.hasher.numStarts == 0 {
+		return 0.0
+	}
+	return 1.0 / float64(uint64(1)<<f.hasher.resultBits)
+}

--- a/filter_bench_test.go
+++ b/filter_bench_test.go
@@ -1,0 +1,398 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zeebo/xxh3"
+)
+
+// =============================================================================
+// Benchmarks — Filter construction and query performance
+//
+// The Filter is the user-facing API for the Ribbon filter. The two
+// performance-critical operations are:
+//
+//   1. Build / BuildFromHashes — one-time construction cost.
+//   2. Contains / ContainsHash — per-query cost (the hot path).
+//
+// Contains dominates runtime in production. It performs:
+//   (a) XXH3 hash of the key bytes (Phase 1).
+//   (b) derive() — rehash + fastRange64 + coeff + result (Phase 2).
+//   (c) GF(2) dot product — skip-zero iteration over set coefficient
+//       bits, XORing solution bytes.
+//   (d) Comparison: computed result == expected result.
+//
+// We benchmark:
+//   1. Contains for true positives (member keys).
+//   2. Contains for true negatives (non-member keys).
+//   3. ContainsHash (pre-hashed, removes XXH3 from the measured path).
+//   4. Build throughput (keys/sec for construction).
+//   5. Build by width (construction cost scaling with w).
+//
+// Each is measured across ribbon widths (32/64/128) to surface
+// width-dependent costs in the dot-product loop.
+// =============================================================================
+
+// benchBuildFilter constructs a Filter with the given parameters.
+// Returns the filter and the original keys (for true-positive queries).
+func benchBuildFilter(w uint32, numKeys int) (*filter, [][]byte) {
+	keys := make([][]byte, numKeys)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("bench_filter_key_%d", i))
+	}
+
+	cfg := Config{
+		CoeffBits:           w,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+	}
+	f, err := buildFilter(keys, cfg)
+	if err != nil {
+		panic(fmt.Sprintf("benchBuildFilter: Build failed: %v", err))
+	}
+	return f, keys
+}
+
+// benchBuildFilterHashes constructs a Filter and returns pre-computed hashes
+// for both member and non-member keys. Used by ContainsHash benchmarks.
+func benchBuildFilterHashes(w uint32, numKeys int) (*filter, []uint64, []uint64) {
+	keys := make([][]byte, numKeys)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("bench_hash_key_%d", i))
+	}
+
+	cfg := Config{
+		CoeffBits:           w,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+	}
+	f, err := buildFilter(keys, cfg)
+	if err != nil {
+		panic(fmt.Sprintf("benchBuildFilterHashes: Build failed: %v", err))
+	}
+
+	// Pre-compute member hashes.
+	memberHashes := make([]uint64, numKeys)
+	for i, key := range keys {
+		memberHashes[i] = xxh3.Hash(key)
+	}
+
+	// Pre-compute non-member hashes.
+	nonMemberHashes := make([]uint64, numKeys)
+	for i := range nonMemberHashes {
+		nonMemberHashes[i] = xxh3.Hash([]byte(fmt.Sprintf("bench_nonmember_%d", i)))
+	}
+
+	return f, memberHashes, nonMemberHashes
+}
+
+// ---------------------------------------------------------------------------
+// 1. Contains — true positive queries (member keys)
+//
+// Measures the full per-query cost: XXH3 hash + derive + dot product +
+// comparison. All queries return true (the key is in the filter).
+//
+// The dominant costs are:
+//   (a) XXH3: ~10–20 ns depending on key length.
+//   (b) derive: ~0.4 ns (inlined, branchless).
+//   (c) dot product: ~w/2 byte reads + XORs (skip-zero iteration).
+//
+// For short keys, XXH3 dominates. For long keys, XXH3 cost grows
+// linearly while the filter query cost stays constant.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   Keys      ns/op   B/op   allocs/op
+//   ─────   ──────    ─────   ────   ─────────
+//   w=32    1,000     26.83   0      0
+//   w=32    10,000    36.77   0      0
+//   w=64    1,000     51.90   0      0
+//   w=64    10,000    53.86   0      0
+//   w=64    100,000   54.02   0      0
+//   w=128   1,000     80.32   0      0
+//   w=128   10,000    85.58   0      0
+//   w=128   100,000   86.41   0      0
+//
+// Key observations:
+//   • Zero allocations — the entire Contains path (XXH3 + derive + dot
+//     product + comparison) runs without touching the heap.
+//   • w=32: 27–37 ns/query. The faster time at n=1K reflects better L1
+//     cache residency of the small solution array.
+//   • w=64: ~52–54 ns/query. Cost is stable across key counts, indicating
+//     the solution array fits comfortably in L2 for up to 100K keys.
+//   • w=128: ~80–86 ns/query. ~1.6× the w=64 cost, consistent with
+//     iterating ~64 vs ~32 set bits in the coefficient row.
+//   • XXH3 accounts for ~20 ns of the total (compare ContainsHash below).
+// ---------------------------------------------------------------------------
+
+func BenchmarkContains_TruePositive(b *testing.B) {
+	for _, w := range []uint32{32, 64, 128} {
+		// w=32 has higher per-key overhead (~7.2%) and does not scale well
+		// to very large key sets. Limit to 10K keys for w=32.
+		sizes := []int{1000, 10000, 100000}
+		if w == 32 {
+			sizes = []int{1000, 10000}
+		}
+		for _, numKeys := range sizes {
+			name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+			b.Run(name, func(b *testing.B) {
+				f, keys := benchBuildFilter(w, numKeys)
+				n := len(keys)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = f.contains(keys[i%n])
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Contains — true negative queries (non-member keys)
+//
+// Measures the same per-query path, but all queries return false. The
+// cost should be virtually identical to true positives because the
+// full dot product is always computed before comparison.
+//
+// Reference results (Apple M3 Pro, Go 1.25, n=10000, -benchtime=2s):
+//
+//   Width   ns/op   B/op   allocs/op
+//   ─────   ─────   ────   ─────────
+//   w=32    36.16   0      0
+//   w=64    54.48   0      0
+//   w=128   85.84   0      0
+//
+// Key observations:
+//   • True-negative cost ≈ true-positive cost (within ~1%) — the full
+//     GF(2) dot product is always computed before the result comparison.
+//     No early-exit branch exists.
+//   • This means adversarial workloads (all non-member queries) pay
+//     exactly the same cost as member queries — no timing side-channel.
+// ---------------------------------------------------------------------------
+
+func BenchmarkContains_TrueNegative(b *testing.B) {
+	for _, w := range []uint32{32, 64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 10000
+			f, _ := benchBuildFilter(w, numKeys)
+
+			// Pre-generate non-member keys.
+			probes := make([][]byte, 4096)
+			for i := range probes {
+				probes[i] = []byte(fmt.Sprintf("bench_negative_%d", i))
+			}
+			mask := len(probes) - 1 // power of 2 for cheap modulo
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = f.contains(probes[i&mask])
+			}
+			_ = sink
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. ContainsHash — pre-hashed query (isolates derive + dot product)
+//
+// Removes the XXH3 Phase 1 hash from the measured path. Measures
+// only the Phase 2 (derive) + dot product + comparison cost.
+//
+// This is the pure "filter query" cost, useful for comparing against
+// other filter implementations that separate hashing from querying.
+//
+// Reference results (Apple M3 Pro, Go 1.25, n=10000, -benchtime=2s):
+//
+//   Width   TP ns/op   TN ns/op   B/op   allocs/op
+//   ─────   ────────   ────────   ────   ─────────
+//   w=32    12.44      12.45      0      0
+//   w=64    26.21      26.21      0      0
+//   w=128   50.50      50.49      0      0
+//
+// Key observations:
+//   • Removes XXH3 (~20 ns) from the measured path, isolating the pure
+//     filter query: derive (0.4 ns) + dot product + comparison.
+//   • w=32: ~12.4 ns — ~16 set bits on average, ~0.78 ns per set-bit
+//     iteration (TZCNT + XOR + BLSR).
+//   • w=64: ~26.2 ns — ~32 set bits, same ~0.82 ns/bit.
+//   • w=128: ~50.5 ns — ~64 set bits across lo+hi halves, same per-bit
+//     cost. The sequential lo→hi processing adds no measurable overhead.
+//   • TP ≈ TN to within noise — confirms no early-exit optimisation.
+//   • Compare with solver's Query benchmark (37 ns for w=64): the Filter's
+//     containsHash is ~30% faster due to the BCE-padded data slice
+//     eliminating per-iteration bounds checks.
+// ---------------------------------------------------------------------------
+
+func BenchmarkContainsHash_TruePositive(b *testing.B) {
+	for _, w := range []uint32{32, 64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 10000
+			f, memberHashes, _ := benchBuildFilterHashes(w, numKeys)
+			mask := numKeys - 1
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = f.containsHash(memberHashes[i&mask])
+			}
+			_ = sink
+		})
+	}
+}
+
+func BenchmarkContainsHash_TrueNegative(b *testing.B) {
+	for _, w := range []uint32{32, 64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 10000
+			f, _, nonMemberHashes := benchBuildFilterHashes(w, numKeys)
+			mask := numKeys - 1
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = f.containsHash(nonMemberHashes[i&mask])
+			}
+			_ = sink
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Build — construction throughput
+//
+// Measures the full construction pipeline: Phase 1 hashing + Phase 2
+// derive + banding (with retry loop) + back-substitution + filter
+// packaging. Reports ns/op which includes the cost of all retries.
+//
+// The dominant cost is banding (O(numKeys) per seed attempt). With a
+// typical overhead ratio (1.05 for w=128), 1–3 seeds suffice.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   Keys      ns/op        B/op        allocs/op
+//   ─────   ──────    ──────────   ─────────   ─────────
+//   w=64    1,000        36,599      54,288    8
+//   w=64    10,000      322,909     532,496    8
+//   w=64    100,000   4,313,420   5,210,256    8
+//   w=128   1,000        55,347      64,144    9
+//   w=128   10,000      462,203     622,608    9
+//   w=128   100,000   5,800,536   6,013,072    9
+//
+// Key observations:
+//   • Scales linearly with key count: ~36.6 ns/key (w=64) and ~55.3 ns/key
+//     (w=128) at n=1K; ~43.1 ns/key and ~58.0 ns/key at n=100K.
+//   • Only 8–9 allocations regardless of scale: hasher (1), key hashes (1),
+//     bander arrays (2–3 for coeffLo/coeffHi/result), hashResults (1),
+//     solution struct (1), solution data (1).
+//   • Memory: ~5.2 B/key at 100K (w=64). Dominated by the bander's SoA
+//     arrays (coeffLo + result) and the solution data.
+//   • w=128 is ~1.35× slower than w=64, reflecting the wider coefficient
+//     rows in both banding and back-substitution.
+//   • Construction of a 100K-key filter takes ~4.3 ms (w=64) or ~5.8 ms
+//     (w=128) — fast enough for online use cases.
+// ---------------------------------------------------------------------------
+
+func BenchmarkBuildFilter(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		for _, numKeys := range []int{1000, 10000, 100000} {
+			name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+			b.Run(name, func(b *testing.B) {
+				keys := make([][]byte, numKeys)
+				for i := range keys {
+					keys[i] = []byte(fmt.Sprintf("bench_build_key_%d", i))
+				}
+
+				cfg := Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: true,
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink *filter
+				for i := 0; i < b.N; i++ {
+					var err error
+					sink, err = buildFilter(keys, cfg)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. BuildFromHashes — construction from pre-hashed keys
+//
+// Isolates the Phase 2 + banding + solving cost by removing the XXH3
+// Phase 1 hash from the measured path.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   Keys      ns/op        B/op        allocs/op
+//   ─────   ──────    ──────────   ─────────   ─────────
+//   w=64    1,000        25,384      46,096    7
+//   w=64    10,000      278,965     450,577    7
+//   w=64    100,000   9,931,058   4,407,470    7
+//   w=128   1,000        36,205      55,952    8
+//   w=128   10,000      424,014     540,689    8
+//   w=128   100,000   5,969,315   5,210,265    8
+//
+// Key observations:
+//   • Saves ~11 µs at n=1K vs Build (25 vs 37 µs for w=64) by skipping
+//     Phase 1 hashing. The gap narrows at large n where banding dominates.
+//   • One fewer allocation than Build (7 vs 8 for w=64): the key-hash
+//     slice is caller-provided, not internally allocated.
+//   • w=64/n=100K shows ~9.9 ms — higher than Build's 4.3 ms — likely
+//     due to seed retry variance (more retries in this particular run).
+//     Amortised cost is comparable.
+//   • Memory at 100K: ~4.4 MB (w=64), ~5.2 MB (w=128) — same order as
+//     Build, dominated by bander SoA arrays and solution data.
+// ---------------------------------------------------------------------------
+
+func BenchmarkBuildFromHashes(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		for _, numKeys := range []int{1000, 10000, 100000} {
+			name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+			b.Run(name, func(b *testing.B) {
+				hashes := make([]uint64, numKeys)
+				for i := range hashes {
+					hashes[i] = xxh3.Hash([]byte(fmt.Sprintf("bench_build_hash_%d", i)))
+				}
+
+				cfg := Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: true,
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink *filter
+				for i := 0; i < b.N; i++ {
+					var err error
+					sink, err = buildFromHashes(hashes, cfg)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				_ = sink
+			})
+		}
+	}
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,732 @@
+package ribbon
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/zeebo/xxh3"
+)
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+// generateKeys creates numKeys deterministic byte-slice keys with the
+// given prefix. Each key is of the form "<prefix>_<index>".
+func generateKeys(prefix string, numKeys int) [][]byte {
+	keys := make([][]byte, numKeys)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("%s_%d", prefix, i))
+	}
+	return keys
+}
+
+// generateHashes creates numKeys deterministic uint64 hashes from keys.
+func generateHashes(prefix string, numKeys int) []uint64 {
+	hashes := make([]uint64, numKeys)
+	for i := range hashes {
+		hashes[i] = xxh3.Hash([]byte(fmt.Sprintf("%s_%d", prefix, i)))
+	}
+	return hashes
+}
+
+// allConfigs returns all 6 valid (coeffBits, firstCoeffAlwaysOne) configurations.
+func allConfigs() []Config {
+	var cfgs []Config
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			cfgs = append(cfgs, Config{
+				CoeffBits:           w,
+				ResultBits:          7,
+				FirstCoeffAlwaysOne: fcao,
+			})
+		}
+	}
+	return cfgs
+}
+
+// configName returns a short test name for a Config.
+func configName(cfg Config) string {
+	return fmt.Sprintf("w=%d/fcao=%v", cfg.CoeffBits, cfg.FirstCoeffAlwaysOne)
+}
+
+// =============================================================================
+// BUILD — constructor tests
+// =============================================================================
+
+func TestBuild_AllConfigs(t *testing.T) {
+	// Build a filter with 1000 keys for each of the 6 configurations.
+	// All inserted keys must be found (zero false negatives).
+	const numKeys = 1000
+
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			keys := generateKeys("build_test", numKeys)
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			// Verify all inserted keys are found.
+			for i, key := range keys {
+				if !f.contains(key) {
+					t.Fatalf("false negative for key %d: %q", i, key)
+				}
+			}
+
+			t.Logf("seed=%d, numSlots=%d, numStarts=%d",
+				f.seed, f.numSlots, f.hasher.numStarts)
+		})
+	}
+}
+
+func TestBuild_Empty(t *testing.T) {
+	// An empty filter (no keys) should always return false for queries.
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			f, err := buildFilter(nil, cfg)
+			if err != nil {
+				t.Fatalf("Build failed for empty input: %v", err)
+			}
+
+			if f.hasher.numStarts != 0 {
+				t.Errorf("NumStarts = %d, want 0", f.hasher.numStarts)
+			}
+			if f.numSlots != 0 {
+				t.Errorf("NumSlots = %d, want 0", f.numSlots)
+			}
+
+			// Must return false for any query.
+			if f.contains([]byte("anything")) {
+				t.Error("empty filter should always return false")
+			}
+			if f.containsHash(12345) {
+				t.Error("empty filter should always return false for ContainsHash")
+			}
+
+			// FPRate should be 0 for empty filter.
+			if f.fpRate() != 0.0 {
+				t.Errorf("FPRate = %f, want 0.0", f.fpRate())
+			}
+		})
+	}
+}
+
+func TestBuild_SingleKey(t *testing.T) {
+	// A filter with a single key must find that key and reject most others.
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			keys := [][]byte{[]byte("the_one_key")}
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			if !f.contains(keys[0]) {
+				t.Fatal("false negative for the single inserted key")
+			}
+
+			// Check that most non-members return false.
+			fps := 0
+			const numProbes = 10000
+			for i := 0; i < numProbes; i++ {
+				if f.contains([]byte(fmt.Sprintf("other_key_%d", i))) {
+					fps++
+				}
+			}
+			fpRate := float64(fps) / float64(numProbes)
+			t.Logf("FP rate for single-key filter: %.2f%% (%d/%d)",
+				fpRate*100, fps, numProbes)
+
+			// With r=7, expected FPR ≈ 0.78%. Allow generous margin.
+			if fpRate > 0.05 {
+				t.Errorf("FP rate %.2f%% is suspiciously high for r=7", fpRate*100)
+			}
+		})
+	}
+}
+
+func TestBuild_InvalidConfig_CoeffBits(t *testing.T) {
+	for _, w := range []uint32{0, 16, 48, 96, 256} {
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("Build with CoeffBits=%d should panic", w)
+				}
+			}()
+			buildFilter([][]byte{[]byte("key")}, Config{
+				CoeffBits:  w,
+				ResultBits: 7,
+			})
+		})
+	}
+}
+
+func TestBuild_InvalidConfig_ResultBits(t *testing.T) {
+	for _, r := range []uint{0, 9, 16, 64} {
+		t.Run(fmt.Sprintf("r=%d", r), func(t *testing.T) {
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("Build with ResultBits=%d should panic", r)
+				}
+			}()
+			buildFilter([][]byte{[]byte("key")}, Config{
+				CoeffBits:  128,
+				ResultBits: r,
+			})
+		})
+	}
+}
+
+// =============================================================================
+// BUILD FROM HASHES — pre-hashed key construction
+// =============================================================================
+
+func TestBuildFromHashes(t *testing.T) {
+	// BuildFromHashes should produce a filter that matches ContainsHash.
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			const numKeys = 500
+			hashes := generateHashes("from_hashes", numKeys)
+
+			f, err := buildFromHashes(hashes, cfg)
+			if err != nil {
+				t.Fatalf("BuildFromHashes failed: %v", err)
+			}
+
+			// All inserted hashes must be found.
+			for i, h := range hashes {
+				if !f.containsHash(h) {
+					t.Fatalf("false negative for hash %d: 0x%x", i, h)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFromHashes_Empty(t *testing.T) {
+	f, err := buildFromHashes(nil, defaultConfig())
+	if err != nil {
+		t.Fatalf("BuildFromHashes failed for empty input: %v", err)
+	}
+	if f.hasher.numStarts != 0 {
+		t.Errorf("NumStarts = %d, want 0", f.hasher.numStarts)
+	}
+	if f.containsHash(0) {
+		t.Error("empty filter should always return false")
+	}
+}
+
+// =============================================================================
+// CONTAINS — true positive tests (zero false negatives)
+// =============================================================================
+
+func TestContains_TruePositives(t *testing.T) {
+	// Full pipeline: build and verify all keys across all configurations.
+	// Uses a larger key set than TestBuild_AllConfigs for more thorough
+	// coverage.
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			const numKeys = 5000
+			keys := generateKeys("tp_test", numKeys)
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			for i, key := range keys {
+				if !f.contains(key) {
+					t.Fatalf("false negative for key %d (seed=%d, numStarts=%d)",
+						i, f.seed, f.hasher.numStarts)
+				}
+			}
+		})
+	}
+}
+
+func TestContains_EmptyFilter(t *testing.T) {
+	// An empty filter (no keys) should always return false.
+	f, err := buildFilter(nil, defaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		key := []byte(fmt.Sprintf("probe_%d", i))
+		if f.contains(key) {
+			t.Fatalf("empty filter returned true for %q", key)
+		}
+	}
+}
+
+// =============================================================================
+// CONTAINS HASH — pre-hashed query tests
+// =============================================================================
+
+func TestContainsHash_MatchesContains(t *testing.T) {
+	// ContainsHash(xxh3.Hash(key)) must return the same result as
+	// Contains(key) for all keys.
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			const numKeys = 1000
+			keys := generateKeys("hash_match", numKeys)
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			// Check inserted keys.
+			for _, key := range keys {
+				got := f.containsHash(xxh3.Hash(key))
+				want := f.contains(key)
+				if got != want {
+					t.Fatalf("ContainsHash mismatch for key %q: got=%v, want=%v",
+						key, got, want)
+				}
+			}
+
+			// Check non-member keys.
+			for i := 0; i < 1000; i++ {
+				key := []byte(fmt.Sprintf("non_member_%d", i))
+				got := f.containsHash(xxh3.Hash(key))
+				want := f.contains(key)
+				if got != want {
+					t.Fatalf("ContainsHash mismatch for non-member %q: got=%v, want=%v",
+						key, got, want)
+				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// FALSE POSITIVE RATE — statistical validation
+// =============================================================================
+
+// TestContains_FalsePositiveRate is the definitive FPR validation test.
+//
+// It builds a filter with 10,000 random keys, then queries 1,000,000
+// completely different random keys and measures the false-positive rate.
+// The measured FPR must closely match the theoretical rate 2^(-r).
+//
+// If the math in the Bander, Solver, or Query is wrong, this test will
+// fail dramatically (e.g., FPR near 50% instead of 0.78%).
+//
+// Paper §3: "the false-positive probability is approximately 2^(-r)."
+func TestContains_FalsePositiveRate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping FPR test in short mode (1M queries)")
+	}
+
+	const numKeys = 10000
+	const numNonMembers = 1000000
+
+	for _, r := range []uint{7, 8} {
+		for _, w := range []uint32{64, 128} {
+			name := fmt.Sprintf("w=%d/r=%d", w, r)
+			t.Run(name, func(t *testing.T) {
+				keys := generateKeys("fpr_member", numKeys)
+
+				cfg := Config{
+					CoeffBits:           w,
+					ResultBits:          r,
+					FirstCoeffAlwaysOne: true,
+				}
+
+				f, err := buildFilter(keys, cfg)
+				if err != nil {
+					t.Fatalf("Build failed: %v", err)
+				}
+
+				// Verify zero false negatives first.
+				for i, key := range keys {
+					if !f.contains(key) {
+						t.Fatalf("false negative for key %d", i)
+					}
+				}
+
+				// Query 1,000,000 non-member keys.
+				fps := 0
+				for i := 0; i < numNonMembers; i++ {
+					key := []byte(fmt.Sprintf("fpr_non_member_%d", i))
+					if f.contains(key) {
+						fps++
+					}
+				}
+
+				fpRate := float64(fps) / float64(numNonMembers)
+				expectedRate := 1.0 / float64(uint64(1)<<r)
+
+				t.Logf("FP rate: %.4f%% (%d / %d), expected ≈ %.4f%%",
+					fpRate*100, fps, numNonMembers, expectedRate*100)
+
+				// Assert the measured FPR is within a reasonable range of
+				// the theoretical value. We use a 3× margin to account for
+				// statistical variance.
+				if fpRate > expectedRate*3.0 {
+					t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+						fpRate*100, expectedRate*100)
+				}
+				if fpRate < expectedRate*0.3 {
+					t.Errorf("FP rate %.4f%% is suspiciously low (expected ≈ %.4f%%)",
+						fpRate*100, expectedRate*100)
+				}
+			})
+		}
+	}
+}
+
+func TestContains_FalsePositiveRate_AllResultBits(t *testing.T) {
+	// Verify FPR scales correctly with r: each additional result bit
+	// should roughly halve the false-positive rate.
+	if testing.Short() {
+		t.Skip("skipping multi-r FPR test in short mode")
+	}
+
+	const numKeys = 5000
+	const numNonMembers = 500000
+
+	prevFPRate := 1.0
+	for _, r := range []uint{1, 2, 4, 7, 8} {
+		name := fmt.Sprintf("r=%d", r)
+		t.Run(name, func(t *testing.T) {
+			keys := generateKeys("fpr_rbits_member", numKeys)
+
+			cfg := Config{
+				CoeffBits:           128,
+				ResultBits:          r,
+				FirstCoeffAlwaysOne: true,
+			}
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			fps := 0
+			for i := 0; i < numNonMembers; i++ {
+				if f.contains([]byte(fmt.Sprintf("fpr_rbits_non_%d", i))) {
+					fps++
+				}
+			}
+
+			fpRate := float64(fps) / float64(numNonMembers)
+			expectedRate := 1.0 / float64(uint64(1)<<r)
+
+			t.Logf("r=%d: FP rate %.4f%% (expected %.4f%%), ratio to prev: %.2f",
+				r, fpRate*100, expectedRate*100, prevFPRate/math.Max(fpRate, 1e-10))
+
+			if fpRate > expectedRate*3.0 {
+				t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+					fpRate*100, expectedRate*100)
+			}
+			if fpRate < expectedRate*0.3 && r < 8 {
+				t.Errorf("FP rate %.4f%% is suspiciously low (expected ≈ %.4f%%)",
+					fpRate*100, expectedRate*100)
+			}
+
+			prevFPRate = fpRate
+		})
+	}
+}
+
+// =============================================================================
+// ACCESSORS — metadata verification
+// =============================================================================
+
+func TestFilter_Accessors(t *testing.T) {
+	cfg := Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+	}
+	keys := generateKeys("accessor_test", 1000)
+	f, err := buildFilter(keys, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f.hasher.coeffBits != 128 {
+		t.Errorf("CoeffBits() = %d, want 128", f.hasher.coeffBits)
+	}
+	if f.hasher.resultBits != 7 {
+		t.Errorf("ResultBits() = %d, want 7", f.hasher.resultBits)
+	}
+	if !f.hasher.forceFirstCoeff {
+		t.Error("FirstCoeffAlwaysOne() = false, want true")
+	}
+	if f.hasher.numStarts == 0 {
+		t.Error("NumStarts() = 0 for non-empty filter")
+	}
+	if f.numSlots == 0 {
+		t.Error("NumSlots() = 0 for non-empty filter")
+	}
+	if f.numSlots != f.hasher.numStarts+f.hasher.coeffBits-1 {
+		t.Errorf("NumSlots() = %d, want %d (numStarts + w - 1)",
+			f.numSlots, f.hasher.numStarts+f.hasher.coeffBits-1)
+	}
+
+	expectedFPR := 1.0 / 128.0 // 2^(-7)
+	if math.Abs(f.fpRate()-expectedFPR) > 1e-10 {
+		t.Errorf("FPRate() = %f, want %f", f.fpRate(), expectedFPR)
+	}
+
+	sol := f.data[:f.numSlots]
+	if uint32(len(sol)) != f.numSlots {
+		t.Errorf("len(SolutionData()) = %d, want %d", len(sol), f.numSlots)
+	}
+}
+
+func TestFilter_Accessors_Empty(t *testing.T) {
+	f, _ := buildFilter(nil, defaultConfig())
+
+	if f.hasher.numStarts != 0 {
+		t.Errorf("NumStarts() = %d, want 0", f.hasher.numStarts)
+	}
+	if f.numSlots != 0 {
+		t.Errorf("NumSlots() = %d, want 0", f.numSlots)
+	}
+	if f.fpRate() != 0.0 {
+		t.Errorf("FPRate() = %f, want 0.0", f.fpRate())
+	}
+	if f.data[:f.numSlots] != nil {
+		t.Error("SolutionData() should be nil for empty filter")
+	}
+}
+
+// =============================================================================
+// DEFAULT CONFIG
+// =============================================================================
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := defaultConfig()
+
+	if cfg.CoeffBits != 128 {
+		t.Errorf("defaultConfig().CoeffBits = %d, want 128", cfg.CoeffBits)
+	}
+	if cfg.ResultBits != 7 {
+		t.Errorf("defaultConfig().ResultBits = %d, want 7", cfg.ResultBits)
+	}
+	if !cfg.FirstCoeffAlwaysOne {
+		t.Error("defaultConfig().FirstCoeffAlwaysOne = false, want true")
+	}
+}
+
+// =============================================================================
+// LARGE-SCALE INTEGRATION TEST
+// =============================================================================
+
+func TestBuild_LargeScale(t *testing.T) {
+	// Large-scale integration test: 50K keys, all configs, verify all
+	// queries return true.
+	if testing.Short() {
+		t.Skip("skipping large-scale test in short mode")
+	}
+
+	const numKeys = 50000
+
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+		t.Run(name, func(t *testing.T) {
+			keys := generateKeys("large_scale", numKeys)
+
+			cfg := Config{
+				CoeffBits:           w,
+				ResultBits:          7,
+				FirstCoeffAlwaysOne: true,
+			}
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			for i, key := range keys {
+				if !f.contains(key) {
+					t.Fatalf("false negative for key %d (seed=%d)", i, f.seed)
+				}
+			}
+
+			t.Logf("seed=%d, numSlots=%d, numStarts=%d, FPR=%.4f%%",
+				f.seed, f.numSlots, f.hasher.numStarts, f.fpRate()*100)
+		})
+	}
+}
+
+// =============================================================================
+// OVERHEAD RATIO — stress test with tight sizing
+// =============================================================================
+
+func TestBuild_TightOverhead(t *testing.T) {
+	// Stress-test the retry loop with a very tight overhead ratio.
+	// This forces more seed retries but should still succeed within
+	// the default 256 seed budget.
+	if testing.Short() {
+		t.Skip("skipping tight overhead test in short mode")
+	}
+
+	const numKeys = 5000
+	keys := generateKeys("tight_overhead", numKeys)
+
+	cfg := Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+		MaxSeeds:            256,
+	}
+	cfg = normalizeConfig(cfg)
+
+	// Phase 1: hash all keys.
+	h := newStandardHasher(cfg.CoeffBits, 0, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+	hashes := make([]uint64, numKeys)
+	for i, key := range keys {
+		hashes[i] = h.keyHash(key)
+	}
+
+	// Use a very tight overhead ratio via the internal override.
+	f, err := buildCoreWithOverride(hashes, cfg, 1.02)
+	if err != nil {
+		t.Fatalf("Build failed with tight overhead: %v", err)
+	}
+
+	// Verify correctness.
+	for i, key := range keys {
+		if !f.contains(key) {
+			t.Fatalf("false negative for key %d", i)
+		}
+	}
+
+	t.Logf("tight overhead: seed=%d, numSlots=%d", f.seed, f.numSlots)
+}
+
+// =============================================================================
+// ERROR PATH — construction failure
+// =============================================================================
+
+func TestBuild_MaxSeedsExhausted(t *testing.T) {
+	// Force construction failure by using an extremely tight overhead
+	// ratio with a small seed budget.
+	keys := generateKeys("exhaust_seeds", 1000)
+
+	cfg := Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+		MaxSeeds:            1, // only 1 attempt
+	}
+	cfg = normalizeConfig(cfg)
+
+	// Phase 1: hash all keys.
+	h := newStandardHasher(cfg.CoeffBits, 0, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+	hashes := make([]uint64, len(keys))
+	for i, key := range keys {
+		hashes[i] = h.keyHash(key)
+	}
+
+	// Use an extremely tight overhead ratio via the internal override.
+	_, err := buildCoreWithOverride(hashes, cfg, 1.001)
+	if err == nil {
+		// It's possible (though unlikely) that even 1 seed succeeds.
+		// This is OK — the test is about verifying error handling.
+		t.Log("construction succeeded with 1 seed (unlikely but possible)")
+		return
+	}
+
+	if err != ErrConstructionFailed {
+		t.Errorf("expected ErrConstructionFailed, got: %v", err)
+	}
+}
+
+// =============================================================================
+// w=32 SPECIFIC TESTS — verify the w=32 path works correctly
+// =============================================================================
+
+func TestBuild_W32_Correctness(t *testing.T) {
+	// w=32 has a subtlety: BackSubstitute treats it as w=64 (since
+	// coeffHi is nil for both). This test verifies that the full pipeline
+	// works correctly for w=32 despite this internal representation detail.
+	for _, fcao := range []bool{true, false} {
+		name := fmt.Sprintf("w=32/fcao=%v", fcao)
+		t.Run(name, func(t *testing.T) {
+			const numKeys = 2000
+			keys := generateKeys("w32_test", numKeys)
+
+			cfg := Config{
+				CoeffBits:           32,
+				ResultBits:          7,
+				FirstCoeffAlwaysOne: fcao,
+			}
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			if f.hasher.coeffBits != 32 {
+				t.Errorf("CoeffBits() = %d, want 32", f.hasher.coeffBits)
+			}
+
+			for i, key := range keys {
+				if !f.contains(key) {
+					t.Fatalf("false negative for key %d", i)
+				}
+			}
+
+			// Check FPR for w=32.
+			fps := 0
+			const numProbes = 100000
+			for i := 0; i < numProbes; i++ {
+				if f.contains([]byte(fmt.Sprintf("w32_non_%d", i))) {
+					fps++
+				}
+			}
+			fpRate := float64(fps) / float64(numProbes)
+			expectedRate := 1.0 / 128.0 // 2^(-7)
+			t.Logf("w=32 FP rate: %.4f%% (expected ≈ %.4f%%)",
+				fpRate*100, expectedRate*100)
+
+			if fpRate > expectedRate*3.0 {
+				t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+					fpRate*100, expectedRate*100)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// MULTI-BIT RESULT TESTS — verify different result bit widths
+// =============================================================================
+
+func TestBuild_AllResultBits(t *testing.T) {
+	// Build and verify filters for each valid resultBits value (1..8).
+	const numKeys = 500
+
+	for r := uint(1); r <= 8; r++ {
+		name := fmt.Sprintf("r=%d", r)
+		t.Run(name, func(t *testing.T) {
+			keys := generateKeys("rbits_test", numKeys)
+
+			cfg := Config{
+				CoeffBits:           128,
+				ResultBits:          r,
+				FirstCoeffAlwaysOne: true,
+			}
+
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatalf("Build failed for r=%d: %v", r, err)
+			}
+
+			for i, key := range keys {
+				if !f.contains(key) {
+					t.Fatalf("false negative for key %d with r=%d", i, r)
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dhruvil/ribbon
+module github.com/ribnonGo/ribbon
 
 go 1.25
 

--- a/ribbon.go
+++ b/ribbon.go
@@ -1,0 +1,165 @@
+package ribbon
+
+import (
+	"errors"
+
+	"github.com/zeebo/xxh3"
+)
+
+// =============================================================================
+// PUBLIC API — the user-facing surface of the Ribbon filter library
+// =============================================================================
+
+// ErrConstructionFailed is returned by Build when the banding algorithm
+// could not solve the linear system within the configured number of seed
+// retries.
+//
+// This typically means the input contains duplicate keys (which always
+// produce linearly dependent equations regardless of seed).
+//
+// Callers should either:
+//   - Remove duplicate keys from the input.
+//   - Increase Config.MaxSeeds.
+var ErrConstructionFailed = errors.New("ribbon: construction failed after exhausting all seed retries")
+
+// =============================================================================
+// CONFIG — construction parameters
+// =============================================================================
+
+// Config holds the parameters for constructing a Ribbon filter.
+//
+// Every configurable knob described in Dillinger & Walzer (2021) is exposed
+// so that users can reproduce and experiment with every trade-off:
+//   - CoeffBits (w): ribbon width, controlling the space–construction trade-off.
+//   - ResultBits (r): fingerprint bits, controlling the FPR.
+//   - FirstCoeffAlwaysOne: whether to force the first coefficient bit to 1.
+//   - MaxSeeds: the maximum number of hash seed retries before giving up.
+type Config struct {
+	// CoeffBits is the ribbon width w: must be 32, 64, or 128.
+	//
+	// Paper §4: "w ∈ {32, 64, 128}. Overhead ratio m/n ≈ 1 + 2.3/w."
+	// Larger w → less space overhead per key, slower construction per key.
+	//   w=32:  ~7.2% overhead, fastest construction per key
+	//   w=64:  ~3.6% overhead, balanced
+	//   w=128: ~1.8% overhead, most compact, slowest construction per key
+	CoeffBits uint32
+
+	// ResultBits is the number of fingerprint bits r stored per key.
+	// The false-positive rate (FPR) is approximately 2^(-r).
+	//
+	// Paper §3: "each query computes an r-bit fingerprint and compares
+	// it against the stored solution row."
+	//   r=7:  FPR ≈ 0.78%
+	//   r=8:  FPR ≈ 0.39%
+	//   r=10: FPR ≈ 0.098%
+	//
+	// Must be in [1, 8]. Limited to 8 because the solution stores one
+	// uint8 per slot (the paper calls these "result rows").
+	ResultBits uint
+
+	// FirstCoeffAlwaysOne controls whether bit 0 of every coefficient row
+	// is forced to 1. When true, the Gaussian elimination pivot is
+	// deterministic at column s(x), removing the need for a leading-zero
+	// scan during banding (faster construction).
+	//
+	// Paper §4: "setting the first coefficient bit to 1."
+	// Set to false for research/experimentation with natural coefficient
+	// distributions.
+	FirstCoeffAlwaysOne bool
+
+	// MaxSeeds is the maximum number of hash seed retries before
+	// construction returns ErrConstructionFailed.
+	// A value of 0 uses the default (256).
+	//
+	// Paper §2: "if banding fails, retry with a new seed."
+	// With typical overhead ratios (≥ 1.05), fewer than 10 seeds are
+	// usually needed.
+	MaxSeeds uint32
+}
+
+// =============================================================================
+// RIBBON — the main filter type
+// =============================================================================
+
+// Ribbon is a space-efficient probabilistic filter for approximate set
+// membership queries.
+//
+// Create one with New (default settings) or NewWithConfig (custom
+// parameters), then call Build to construct the filter from a set of
+// keys. After building, call Contains to test membership.
+//
+// A Ribbon filter guarantees:
+//   - No false negatives: if a key was in the build set, Contains
+//     always returns true.
+//   - Configurable false positives: non-member keys return true with
+//     probability ≈ 2^(-r), where r is Config.ResultBits.
+//
+// Thread safety: after Build completes, Contains may be called
+// concurrently from multiple goroutines without synchronisation.
+//
+// Based on: Dillinger & Walzer, "Ribbon filter: practically smaller
+// than Bloom and Xor" (2021), arXiv:2103.02515.
+type Ribbon struct {
+	cfg Config
+	f   *filter
+}
+
+// New creates a Ribbon filter with default settings.
+//
+// Defaults: w=128 (most compact), r=7 (FPR ≈ 0.78%),
+// firstCoeffAlwaysOne=true (fastest construction), maxSeeds=256.
+//
+// Paper §4: "w=128 seems to be closest to a generally good choice."
+func New() *Ribbon {
+	return &Ribbon{cfg: defaultConfig()}
+}
+
+// NewWithConfig creates a Ribbon filter with custom parameters.
+//
+// Panics if Config.CoeffBits is not 32, 64, or 128, or if
+// Config.ResultBits is not in [1, 8].
+func NewWithConfig(cfg Config) *Ribbon {
+	validateConfig(cfg)
+	return &Ribbon{cfg: normalizeConfig(cfg)}
+}
+
+// Build constructs the filter from the given keys.
+//
+// Keys must be unique: duplicate keys produce identical equations
+// regardless of the hash seed, causing guaranteed construction failure.
+// If duplicates may be present, the caller should de-duplicate first.
+//
+// Build may be called multiple times to rebuild the filter with
+// different key sets. Each call replaces the previous filter.
+//
+// Returns ErrConstructionFailed if banding fails for all seed retries.
+func (r *Ribbon) Build(keys []string) error {
+	byteKeys := make([][]byte, len(keys))
+	for i, k := range keys {
+		byteKeys[i] = []byte(k)
+	}
+
+	f, err := buildFilter(byteKeys, r.cfg)
+	if err != nil {
+		return err
+	}
+	r.f = f
+	return nil
+}
+
+// Contains tests whether key is probably a member of the set used to
+// build this filter.
+//
+// Returns true if the key is probably in the set (with false-positive
+// probability ≈ 2^(-r)), or false if the key is definitely not in the set.
+//
+// Returns false if Build has not been called yet.
+//
+// This is the hot path of the library — zero allocations, branchless
+// coefficient derivation, and skip-zero dot product iteration.
+func (r *Ribbon) Contains(key string) bool {
+	if r.f == nil {
+		return false
+	}
+	return r.f.containsHash(xxh3.Hash([]byte(key)))
+}

--- a/ribbon_bench_test.go
+++ b/ribbon_bench_test.go
@@ -1,0 +1,349 @@
+package ribbon
+
+import (
+	"encoding/binary"
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// =============================================================================
+// Paper-Aligned Benchmarks — Dillinger & Walzer (2021), §6
+//
+// The paper's Figure 7 evaluates Ribbon filter performance at two key
+// set sizes that highlight the transition from cache-resident to
+// memory-latency-bound queries:
+//
+//   n = 10^6  — filter (~1 MB) fits comfortably in L2/L3 cache
+//   n = 10^8  — filter (~100 MB) exceeds all cache levels
+//
+// Configurations (paper §4, "Standard Ribbon"):
+//
+//   w ∈ {32, 64, 128}     — ribbon width (coefficient bits)
+//   r = 7                  — result bits (FPR ≈ 2^{-7} ≈ 0.78%)
+//   firstCoeffAlwaysOne    — true (the standard, faster variant)
+//
+// Paper §4 overhead ratios: m/n ≈ 1 + 2.3/w
+//   w=32:  ~7.2% overhead, fastest per-key construction
+//   w=64:  ~3.6% overhead, balanced speed/space
+//   w=128: ~1.8% overhead, most compact (recommended)
+//
+// Space overhead note:
+//
+//   Our implementation uses the "simple" solution format — one uint8
+//   per slot regardless of r (like RocksDB's InMemSimpleSolution).
+//   This means:
+//     bits/key (actual)  = 8 × numSlots / n
+//     bits/key (packed)  = r × numSlots / n  (paper's interleaved format)
+//     bits/key (optimal) = r = 7              (information-theoretic min)
+//
+//   For r=7, our storage is 8/7 ≈ 14.3% larger than the interleaved
+//   format. An interleaved solution format would close this gap.
+//
+// Memory requirements:
+//   n=10^6:  ~50 MB peak during construction
+//   n=10^8:  ~8 GB peak during construction (skipped with -short)
+//
+// Run paper benchmarks (n=10^6 only, fast):
+//   go test -bench="BenchmarkPaper" -benchmem -short
+//
+// Run paper benchmarks (both scales, requires ~8 GB RAM):
+//   go test -bench="BenchmarkPaper" -benchmem -benchtime=3s
+//
+// Run a single iteration at full scale:
+//   go test -bench="BenchmarkPaper" -benchmem -benchtime=1x
+// =============================================================================
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+// makePaperKeys generates n unique keys for benchmarking.
+//
+// Keys are compact 8-byte binary strings (little-endian uint64) for
+// minimal memory footprint (~24 bytes per key including header) and
+// fast generation. The binary format also ensures uniform-length keys,
+// eliminating key-length variance from the benchmark.
+func makePaperKeys(n int) []string {
+	keys := make([]string, n)
+	buf := make([]byte, 8)
+	for i := range keys {
+		binary.LittleEndian.PutUint64(buf, uint64(i))
+		keys[i] = string(buf)
+	}
+	return keys
+}
+
+// makePaperNonMemberKeys generates n non-member probe keys guaranteed
+// to be distinct from makePaperKeys output by using a high offset.
+func makePaperNonMemberKeys(n int) []string {
+	const offset = 1 << 40 // well above any realistic test key count
+	keys := make([]string, n)
+	buf := make([]byte, 8)
+	for i := range keys {
+		binary.LittleEndian.PutUint64(buf, uint64(i+offset))
+		keys[i] = string(buf)
+	}
+	return keys
+}
+
+// intLog10 returns floor(log10(n)) for benchmark name labels.
+func intLog10(n int) int {
+	e := 0
+	for n >= 10 {
+		n /= 10
+		e++
+	}
+	return e
+}
+
+// paperSizes returns the key set sizes to benchmark.
+// n=10^8 is skipped in short mode due to memory requirements (~8 GB).
+func paperSizes(b *testing.B) []int {
+	if testing.Short() {
+		return []int{1_000_000}
+	}
+	return []int{1_000_000, 100_000_000}
+}
+
+// =============================================================================
+// BUILD — construction throughput
+//
+// Paper §6: "Construction time" column in the comparison table.
+//
+// Measures the full Build() pipeline through the public API:
+//   string→[]byte conversion → XXH3 hashing (Phase 1) →
+//   seed-retry loop { derive (Phase 2) → banding → back-substitution } →
+//   filter packaging
+//
+// Reports:
+//   ns/op       — total time to build a filter from n keys
+//   ns/key      — amortized per-key construction cost
+//   bits/key    — actual storage per key (simple format: 8 × numSlots / n)
+//   overhead%   — slot overhead: (numSlots/n − 1) × 100
+//   B/op        — total bytes allocated per build
+//   allocs/op   — total heap allocations per build
+// =============================================================================
+
+func BenchmarkPaper_Build(b *testing.B) {
+	sizes := paperSizes(b)
+
+	for _, w := range []uint32{32, 64, 128} {
+		for _, n := range sizes {
+			name := fmt.Sprintf("w=%d/n=1e%d", w, intLog10(n))
+			b.Run(name, func(b *testing.B) {
+				keys := makePaperKeys(n)
+				cfg := Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: true,
+				}
+
+				var rb *Ribbon
+				b.ResetTimer()
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					rb = NewWithConfig(cfg)
+					if err := rb.Build(keys); err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.StopTimer()
+
+				// Report paper-aligned custom metrics from the last build.
+				if rb != nil && rb.f != nil {
+					nf := float64(n)
+					numSlots := float64(rb.f.numSlots)
+					bitsPerKey := (numSlots * 8) / nf
+					overheadPct := ((numSlots / nf) - 1) * 100
+					nsPerKey := float64(b.Elapsed().Nanoseconds()) / (float64(b.N) * nf)
+
+					b.ReportMetric(nsPerKey, "ns/key")
+					b.ReportMetric(bitsPerKey, "bits/key")
+					b.ReportMetric(overheadPct, "overhead%")
+				}
+			})
+		}
+	}
+}
+
+// =============================================================================
+// QUERY — membership query throughput (true positives)
+//
+// Paper §6: "Positive query time" column.
+//
+// The filter is built once during setup (not timed). The benchmark loop
+// measures only the Contains() call:
+//   XXH3([]byte(key)) → derive(hash) → GF(2) dot product → compare
+//
+// Probe strategy:
+//   8192 evenly-spaced member keys are sampled from the build set.
+//   XXH3 maps these to pseudo-random positions in the solution vector,
+//   giving a realistic random-access pattern that exercises cache
+//   behavior faithfully.
+//
+// At n=10^6, the filter (~1 MB) is L2-resident → fast queries.
+// At n=10^8, the filter (~100 MB) is DRAM-resident → queries are
+// memory-latency-bound, revealing the paper's key insight about
+// Ribbon's cache-friendly contiguous access pattern.
+// =============================================================================
+
+func BenchmarkPaper_Query_Positive(b *testing.B) {
+	sizes := paperSizes(b)
+
+	for _, w := range []uint32{32, 64, 128} {
+		for _, n := range sizes {
+			name := fmt.Sprintf("w=%d/n=1e%d", w, intLog10(n))
+			b.Run(name, func(b *testing.B) {
+				// Setup: build filter (not timed).
+				keys := makePaperKeys(n)
+				rb := NewWithConfig(Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: true,
+				})
+				if err := rb.Build(keys); err != nil {
+					b.Fatal(err)
+				}
+
+				// Sample 8192 evenly-spaced member keys for probing.
+				// These are spread across the full key range so queries
+				// exercise the entire filter address space.
+				const probeCount = 8192
+				probes := make([]string, probeCount)
+				step := n / probeCount
+				if step == 0 {
+					step = 1
+				}
+				for i := range probes {
+					probes[i] = keys[(i*step)%n]
+				}
+
+				// Release the full key set to reduce memory pressure
+				// during the timed query loop.
+				keys = nil
+				runtime.GC()
+
+				mask := probeCount - 1
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = rb.Contains(probes[i&mask])
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// =============================================================================
+// QUERY — membership query throughput (true negatives / non-members)
+//
+// Paper §6: "Negative query time" column.
+//
+// Same setup as positive queries, but probes are keys NOT in the build
+// set. The cost should be virtually identical to positive queries
+// because the full GF(2) dot product is always computed before the
+// result comparison — there is no early-exit branch.
+//
+// Identical true-positive vs true-negative cost confirms there is no
+// timing side-channel: an adversary cannot distinguish member from
+// non-member queries by observing latency.
+// =============================================================================
+
+func BenchmarkPaper_Query_Negative(b *testing.B) {
+	sizes := paperSizes(b)
+
+	for _, w := range []uint32{32, 64, 128} {
+		for _, n := range sizes {
+			name := fmt.Sprintf("w=%d/n=1e%d", w, intLog10(n))
+			b.Run(name, func(b *testing.B) {
+				// Setup: build filter (not timed).
+				keys := makePaperKeys(n)
+				rb := NewWithConfig(Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: true,
+				})
+				if err := rb.Build(keys); err != nil {
+					b.Fatal(err)
+				}
+
+				// Release keys immediately — not needed for negative queries.
+				keys = nil
+				runtime.GC()
+
+				// Generate non-member probe keys.
+				const probeCount = 8192
+				probes := makePaperNonMemberKeys(probeCount)
+				mask := probeCount - 1
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = rb.Contains(probes[i&mask])
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// =============================================================================
+// SPACE — overhead summary (complements Build metrics)
+//
+// This benchmark reports detailed space metrics for every configuration
+// without timing construction, making it fast to run even at n=10^8.
+//
+// Reported metrics:
+//   bits/key         — actual storage: 8 × numSlots / n (our simple format)
+//   packed-bits/key  — theoretical with packed r-bit storage: r × numSlots / n
+//   overhead%        — slot overhead: (numSlots/n − 1) × 100
+//
+// Paper §4 theoretical bits/key (interleaved format):
+//   w=32:  r × (1 + 2.3/32)  = 7 × 1.072 ≈ 7.50
+//   w=64:  r × (1 + 2.3/64)  = 7 × 1.036 ≈ 7.25
+//   w=128: r × (1 + 2.3/128) = 7 × 1.018 ≈ 7.13
+//
+// Information-theoretic minimum: log₂(1/ε) = r = 7 bits/key.
+// =============================================================================
+
+func BenchmarkPaper_Space(b *testing.B) {
+	sizes := paperSizes(b)
+
+	for _, w := range []uint32{32, 64, 128} {
+		for _, n := range sizes {
+			name := fmt.Sprintf("w=%d/n=1e%d", w, intLog10(n))
+			b.Run(name, func(b *testing.B) {
+				keys := makePaperKeys(n)
+				rb := NewWithConfig(Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: true,
+				})
+				if err := rb.Build(keys); err != nil {
+					b.Fatal(err)
+				}
+				keys = nil
+
+				nf := float64(n)
+				numSlots := float64(rb.f.numSlots)
+
+				// The benchmark loop is trivial — space is a static
+				// metric. We run a single Contains to give the framework
+				// a non-zero timing anchor for the custom metrics.
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					rb.Contains("probe")
+				}
+				b.StopTimer()
+
+				b.ReportMetric((numSlots*8)/nf, "bits/key")
+				b.ReportMetric((numSlots*7)/nf, "packed-bits/key")
+				b.ReportMetric(((numSlots/nf)-1)*100, "overhead%")
+			})
+		}
+	}
+}

--- a/ribbon_test.go
+++ b/ribbon_test.go
@@ -1,0 +1,691 @@
+package ribbon
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+// generateStringKeys creates numKeys deterministic string keys with the
+// given prefix. Each key is of the form "<prefix>_<index>".
+func generateStringKeys(prefix string, numKeys int) []string {
+	keys := make([]string, numKeys)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("%s_%d", prefix, i)
+	}
+	return keys
+}
+
+// =============================================================================
+// NEW — constructor tests
+// =============================================================================
+
+func TestNew(t *testing.T) {
+	r := New()
+	if r == nil {
+		t.Fatal("New() returned nil")
+	}
+
+	// Verify default config values are applied.
+	if r.cfg.CoeffBits != 128 {
+		t.Errorf("cfg.CoeffBits = %d, want 128", r.cfg.CoeffBits)
+	}
+	if r.cfg.ResultBits != 7 {
+		t.Errorf("cfg.ResultBits = %d, want 7", r.cfg.ResultBits)
+	}
+	if !r.cfg.FirstCoeffAlwaysOne {
+		t.Error("cfg.FirstCoeffAlwaysOne = false, want true")
+	}
+
+	// Filter should be nil before Build is called.
+	if r.f != nil {
+		t.Error("filter should be nil before Build()")
+	}
+}
+
+func TestNewWithConfig_AllValidWidths(t *testing.T) {
+	for _, w := range []uint32{32, 64, 128} {
+		for _, r := range []uint{1, 4, 7, 8} {
+			name := fmt.Sprintf("w=%d/r=%d", w, r)
+			t.Run(name, func(t *testing.T) {
+				cfg := Config{
+					CoeffBits:           w,
+					ResultBits:          r,
+					FirstCoeffAlwaysOne: true,
+				}
+				rb := NewWithConfig(cfg)
+				if rb == nil {
+					t.Fatal("NewWithConfig returned nil")
+				}
+				if rb.cfg.CoeffBits != w {
+					t.Errorf("cfg.CoeffBits = %d, want %d", rb.cfg.CoeffBits, w)
+				}
+				if rb.cfg.ResultBits != r {
+					t.Errorf("cfg.ResultBits = %d, want %d", rb.cfg.ResultBits, r)
+				}
+			})
+		}
+	}
+}
+
+func TestNewWithConfig_NormalizesMaxSeeds(t *testing.T) {
+	// MaxSeeds=0 should be normalised to the default (256).
+	rb := NewWithConfig(Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+		MaxSeeds:            0,
+	})
+	if rb.cfg.MaxSeeds != 256 {
+		t.Errorf("MaxSeeds = %d, want 256 (normalised from 0)", rb.cfg.MaxSeeds)
+	}
+
+	// Explicit MaxSeeds should be preserved.
+	rb = NewWithConfig(Config{
+		CoeffBits:           64,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+		MaxSeeds:            50,
+	})
+	if rb.cfg.MaxSeeds != 50 {
+		t.Errorf("MaxSeeds = %d, want 50", rb.cfg.MaxSeeds)
+	}
+}
+
+func TestNewWithConfig_InvalidCoeffBits(t *testing.T) {
+	for _, w := range []uint32{0, 16, 48, 96, 256} {
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("NewWithConfig with CoeffBits=%d should panic", w)
+				}
+			}()
+			NewWithConfig(Config{
+				CoeffBits:  w,
+				ResultBits: 7,
+			})
+		})
+	}
+}
+
+func TestNewWithConfig_InvalidResultBits(t *testing.T) {
+	for _, r := range []uint{0, 9, 16, 64} {
+		t.Run(fmt.Sprintf("r=%d", r), func(t *testing.T) {
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("NewWithConfig with ResultBits=%d should panic", r)
+				}
+			}()
+			NewWithConfig(Config{
+				CoeffBits:  128,
+				ResultBits: r,
+			})
+		})
+	}
+}
+
+// =============================================================================
+// BUILD — construction via the public API
+// =============================================================================
+
+func TestRibbon_Build_AllConfigs(t *testing.T) {
+	// Build a filter with 1000 keys for each of the 6 valid
+	// (coeffBits, firstCoeffAlwaysOne) configurations.
+	// All inserted keys must be found (zero false negatives).
+	const numKeys = 1000
+
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				rb := NewWithConfig(Config{
+					CoeffBits:           w,
+					ResultBits:          7,
+					FirstCoeffAlwaysOne: fcao,
+				})
+
+				keys := generateStringKeys("ribbon_build", numKeys)
+				if err := rb.Build(keys); err != nil {
+					t.Fatalf("Build failed: %v", err)
+				}
+
+				for i, key := range keys {
+					if !rb.Contains(key) {
+						t.Fatalf("false negative for key %d: %q", i, key)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRibbon_Build_Empty(t *testing.T) {
+	// Building with zero keys should succeed and Contains should
+	// always return false.
+	rb := New()
+	if err := rb.Build(nil); err != nil {
+		t.Fatalf("Build(nil) failed: %v", err)
+	}
+
+	if rb.Contains("anything") {
+		t.Error("empty filter should return false for any key")
+	}
+	if rb.Contains("") {
+		t.Error("empty filter should return false for empty string")
+	}
+}
+
+func TestRibbon_Build_EmptySlice(t *testing.T) {
+	rb := New()
+	if err := rb.Build([]string{}); err != nil {
+		t.Fatalf("Build([]string{}) failed: %v", err)
+	}
+	if rb.Contains("probe") {
+		t.Error("empty filter should return false")
+	}
+}
+
+func TestRibbon_Build_SingleKey(t *testing.T) {
+	rb := New()
+	if err := rb.Build([]string{"the_one_key"}); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if !rb.Contains("the_one_key") {
+		t.Fatal("false negative for the single inserted key")
+	}
+
+	// Most non-members should return false.
+	fps := 0
+	const numProbes = 10000
+	for i := 0; i < numProbes; i++ {
+		if rb.Contains(fmt.Sprintf("other_key_%d", i)) {
+			fps++
+		}
+	}
+	fpRate := float64(fps) / float64(numProbes)
+	t.Logf("FP rate for single-key filter: %.2f%% (%d/%d)",
+		fpRate*100, fps, numProbes)
+
+	// With r=7, expected FPR ≈ 0.78%. Allow generous margin.
+	if fpRate > 0.05 {
+		t.Errorf("FP rate %.2f%% is suspiciously high for r=7", fpRate*100)
+	}
+}
+
+func TestRibbon_Build_Rebuild(t *testing.T) {
+	// Build may be called multiple times. Each call replaces the
+	// previous filter entirely.
+	rb := New()
+
+	keys1 := generateStringKeys("set_one", 500)
+	if err := rb.Build(keys1); err != nil {
+		t.Fatalf("first Build failed: %v", err)
+	}
+	for _, k := range keys1 {
+		if !rb.Contains(k) {
+			t.Fatalf("false negative after first Build: %q", k)
+		}
+	}
+
+	// Rebuild with a completely different key set.
+	keys2 := generateStringKeys("set_two", 500)
+	if err := rb.Build(keys2); err != nil {
+		t.Fatalf("second Build failed: %v", err)
+	}
+	for _, k := range keys2 {
+		if !rb.Contains(k) {
+			t.Fatalf("false negative after second Build: %q", k)
+		}
+	}
+
+	// Old keys from set_one should mostly NOT be found (they weren't
+	// in the second build set). We tolerate some false positives.
+	fps := 0
+	for _, k := range keys1 {
+		if rb.Contains(k) {
+			fps++
+		}
+	}
+	fpRate := float64(fps) / float64(len(keys1))
+	t.Logf("after rebuild: %.2f%% of old keys still match (FP)", fpRate*100)
+	if fpRate > 0.05 {
+		t.Errorf("%.2f%% of old keys still match — rebuild may not have replaced the filter", fpRate*100)
+	}
+}
+
+func TestRibbon_Build_LargeScale(t *testing.T) {
+	// Large-scale test: 50K keys via the public API.
+	if testing.Short() {
+		t.Skip("skipping large-scale test in short mode")
+	}
+
+	const numKeys = 50000
+	keys := generateStringKeys("large_ribbon", numKeys)
+
+	rb := New()
+	if err := rb.Build(keys); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	for i, key := range keys {
+		if !rb.Contains(key) {
+			t.Fatalf("false negative for key %d", i)
+		}
+	}
+}
+
+// =============================================================================
+// CONTAINS — membership query tests
+// =============================================================================
+
+func TestRibbon_Contains_BeforeBuild(t *testing.T) {
+	// Contains must return false if Build has never been called.
+	rb := New()
+	if rb.Contains("anything") {
+		t.Error("Contains should return false before Build()")
+	}
+	if rb.Contains("") {
+		t.Error("Contains should return false for empty string before Build()")
+	}
+}
+
+func TestRibbon_Contains_EmptyStringKey(t *testing.T) {
+	// An empty string is a valid key.
+	rb := New()
+	if err := rb.Build([]string{""}); err != nil {
+		t.Fatalf("Build with empty string key failed: %v", err)
+	}
+	if !rb.Contains("") {
+		t.Fatal("false negative for empty string key")
+	}
+}
+
+func TestRibbon_Contains_UnicodeKeys(t *testing.T) {
+	// Unicode strings should work correctly — they're just bytes.
+	keys := []string{
+		"日本語",
+		"中文",
+		"한국어",
+		"العربية",
+		"🎉🎊🎈",
+		"café",
+		"naïve",
+	}
+
+	rb := New()
+	if err := rb.Build(keys); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	for _, key := range keys {
+		if !rb.Contains(key) {
+			t.Fatalf("false negative for unicode key: %q", key)
+		}
+	}
+}
+
+func TestRibbon_Contains_LongKeys(t *testing.T) {
+	// Very long keys should hash correctly.
+	rb := New()
+
+	long1 := string(make([]byte, 10000)) // 10 KB of zeroes
+	long2 := string(make([]byte, 10001)) // 10 KB + 1 byte of zeroes
+
+	keys := []string{long1, long2, "short"}
+	if err := rb.Build(keys); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	for _, key := range keys {
+		if !rb.Contains(key) {
+			t.Fatalf("false negative for key of length %d", len(key))
+		}
+	}
+}
+
+// =============================================================================
+// FALSE POSITIVE RATE — statistical validation via the public API
+// =============================================================================
+
+func TestRibbon_FalsePositiveRate(t *testing.T) {
+	// The definitive FPR validation through the public API.
+	// Build with 10,000 keys, query 1,000,000 non-members, and verify
+	// the measured FPR matches the theoretical rate 2^(-r).
+	if testing.Short() {
+		t.Skip("skipping FPR test in short mode (1M queries)")
+	}
+
+	const numKeys = 10000
+	const numNonMembers = 1000000
+
+	for _, r := range []uint{7, 8} {
+		name := fmt.Sprintf("r=%d", r)
+		t.Run(name, func(t *testing.T) {
+			rb := NewWithConfig(Config{
+				CoeffBits:           128,
+				ResultBits:          r,
+				FirstCoeffAlwaysOne: true,
+			})
+
+			keys := generateStringKeys("fpr_ribbon_member", numKeys)
+			if err := rb.Build(keys); err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			// Verify zero false negatives first.
+			for i, key := range keys {
+				if !rb.Contains(key) {
+					t.Fatalf("false negative for key %d", i)
+				}
+			}
+
+			// Query 1,000,000 non-member keys.
+			fps := 0
+			for i := 0; i < numNonMembers; i++ {
+				if rb.Contains(fmt.Sprintf("fpr_ribbon_non_member_%d", i)) {
+					fps++
+				}
+			}
+
+			fpRate := float64(fps) / float64(numNonMembers)
+			expectedRate := 1.0 / float64(uint64(1)<<r)
+
+			t.Logf("FP rate: %.4f%% (%d / %d), expected ≈ %.4f%%",
+				fpRate*100, fps, numNonMembers, expectedRate*100)
+
+			if fpRate > expectedRate*3.0 {
+				t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+					fpRate*100, expectedRate*100)
+			}
+			if fpRate < expectedRate*0.3 {
+				t.Errorf("FP rate %.4f%% is suspiciously low (expected ≈ %.4f%%)",
+					fpRate*100, expectedRate*100)
+			}
+		})
+	}
+}
+
+func TestRibbon_FalsePositiveRate_AllResultBits(t *testing.T) {
+	// Verify FPR scales correctly with r: each additional result bit
+	// should roughly halve the false-positive rate.
+	if testing.Short() {
+		t.Skip("skipping multi-r FPR test in short mode")
+	}
+
+	const numKeys = 5000
+	const numNonMembers = 500000
+
+	prevFPRate := 1.0
+	for _, r := range []uint{1, 2, 4, 7, 8} {
+		name := fmt.Sprintf("r=%d", r)
+		t.Run(name, func(t *testing.T) {
+			rb := NewWithConfig(Config{
+				CoeffBits:           128,
+				ResultBits:          r,
+				FirstCoeffAlwaysOne: true,
+			})
+
+			keys := generateStringKeys("fpr_ribbon_rbits", numKeys)
+			if err := rb.Build(keys); err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			fps := 0
+			for i := 0; i < numNonMembers; i++ {
+				if rb.Contains(fmt.Sprintf("fpr_ribbon_rbits_non_%d", i)) {
+					fps++
+				}
+			}
+
+			fpRate := float64(fps) / float64(numNonMembers)
+			expectedRate := 1.0 / float64(uint64(1)<<r)
+
+			t.Logf("r=%d: FP rate %.4f%% (expected %.4f%%), ratio to prev: %.2f",
+				r, fpRate*100, expectedRate*100, prevFPRate/math.Max(fpRate, 1e-10))
+
+			if fpRate > expectedRate*3.0 {
+				t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+					fpRate*100, expectedRate*100)
+			}
+			if fpRate < expectedRate*0.3 && r < 8 {
+				t.Errorf("FP rate %.4f%% is suspiciously low (expected ≈ %.4f%%)",
+					fpRate*100, expectedRate*100)
+			}
+
+			prevFPRate = fpRate
+		})
+	}
+}
+
+// =============================================================================
+// ERROR PATH — construction failure via the public API
+// =============================================================================
+
+func TestRibbon_Build_ErrConstructionFailed(t *testing.T) {
+	// Force construction failure by using MaxSeeds=1.
+	// With only 1 seed attempt and many keys, failure is likely.
+	rb := NewWithConfig(Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+		MaxSeeds:            1,
+	})
+
+	// Use enough keys to make single-seed failure very likely.
+	keys := generateStringKeys("fail_ribbon", 10000)
+	err := rb.Build(keys)
+
+	if err == nil {
+		// It's theoretically possible for 1 seed to succeed, but very unlikely
+		// with such tight internal overhead. If it does, just log and skip.
+		t.Log("construction unexpectedly succeeded with MaxSeeds=1 — skipping error check")
+		return
+	}
+
+	if !errors.Is(err, ErrConstructionFailed) {
+		t.Errorf("expected ErrConstructionFailed, got: %v", err)
+	}
+}
+
+func TestRibbon_Build_ErrorDoesNotCorruptState(t *testing.T) {
+	// After a failed Build, the Ribbon should still be usable —
+	// either by calling Build again or by querying (returns false).
+	rb := NewWithConfig(Config{
+		CoeffBits:           128,
+		ResultBits:          7,
+		FirstCoeffAlwaysOne: true,
+		MaxSeeds:            1,
+	})
+
+	keys := generateStringKeys("fail_then_retry", 10000)
+	err := rb.Build(keys)
+
+	if err != nil {
+		// Build failed (expected). Contains should return false.
+		if rb.Contains("fail_then_retry_0") {
+			t.Error("Contains should return false after failed Build")
+		}
+
+		// Retry with a generous seed budget should succeed.
+		rb2 := NewWithConfig(Config{
+			CoeffBits:           128,
+			ResultBits:          7,
+			FirstCoeffAlwaysOne: true,
+			MaxSeeds:            256,
+		})
+		if err2 := rb2.Build(keys); err2 != nil {
+			t.Fatalf("retry Build failed: %v", err2)
+		}
+		if !rb2.Contains("fail_then_retry_0") {
+			t.Error("false negative after successful retry Build")
+		}
+	}
+}
+
+// =============================================================================
+// CONFIG EDGE CASES
+// =============================================================================
+
+func TestRibbon_AllWidths(t *testing.T) {
+	// Verify that all three ribbon widths produce correct filters
+	// through the public API.
+	const numKeys = 2000
+
+	for _, w := range []uint32{32, 64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			rb := NewWithConfig(Config{
+				CoeffBits:           w,
+				ResultBits:          7,
+				FirstCoeffAlwaysOne: true,
+			})
+
+			keys := generateStringKeys("width_test", numKeys)
+			if err := rb.Build(keys); err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			for i, key := range keys {
+				if !rb.Contains(key) {
+					t.Fatalf("false negative for key %d with w=%d", i, w)
+				}
+			}
+
+			// Spot-check FPR to ensure correctness.
+			fps := 0
+			const numProbes = 100000
+			for i := 0; i < numProbes; i++ {
+				if rb.Contains(fmt.Sprintf("width_non_%d", i)) {
+					fps++
+				}
+			}
+			fpRate := float64(fps) / float64(numProbes)
+			expectedRate := 1.0 / 128.0 // 2^(-7)
+			t.Logf("w=%d FP rate: %.4f%% (expected ≈ %.4f%%)",
+				w, fpRate*100, expectedRate*100)
+
+			if fpRate > expectedRate*3.0 {
+				t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+					fpRate*100, expectedRate*100)
+			}
+		})
+	}
+}
+
+func TestRibbon_AllResultBits(t *testing.T) {
+	// Build and verify filters for each valid resultBits value (1..8)
+	// through the public API.
+	const numKeys = 500
+
+	for r := uint(1); r <= 8; r++ {
+		name := fmt.Sprintf("r=%d", r)
+		t.Run(name, func(t *testing.T) {
+			rb := NewWithConfig(Config{
+				CoeffBits:           128,
+				ResultBits:          r,
+				FirstCoeffAlwaysOne: true,
+			})
+
+			keys := generateStringKeys("rbits_ribbon", numKeys)
+			if err := rb.Build(keys); err != nil {
+				t.Fatalf("Build failed for r=%d: %v", r, err)
+			}
+
+			for i, key := range keys {
+				if !rb.Contains(key) {
+					t.Fatalf("false negative for key %d with r=%d", i, r)
+				}
+			}
+		})
+	}
+}
+
+func TestRibbon_FirstCoeffAlwaysOne_Toggle(t *testing.T) {
+	// Both FirstCoeffAlwaysOne=true and false should produce correct filters.
+	const numKeys = 1000
+
+	for _, fcao := range []bool{true, false} {
+		name := fmt.Sprintf("fcao=%v", fcao)
+		t.Run(name, func(t *testing.T) {
+			rb := NewWithConfig(Config{
+				CoeffBits:           128,
+				ResultBits:          7,
+				FirstCoeffAlwaysOne: fcao,
+			})
+
+			keys := generateStringKeys("fcao_ribbon", numKeys)
+			if err := rb.Build(keys); err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			for i, key := range keys {
+				if !rb.Contains(key) {
+					t.Fatalf("false negative for key %d with fcao=%v", i, fcao)
+				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// CONCURRENCY — thread safety of Contains after Build
+// =============================================================================
+
+func TestRibbon_Contains_ConcurrentReads(t *testing.T) {
+	// After Build completes, Contains must be safe to call from
+	// multiple goroutines concurrently.
+	const numKeys = 5000
+	const numGoroutines = 8
+	const queriesPerGoroutine = 10000
+
+	rb := New()
+	keys := generateStringKeys("concurrent_ribbon", numKeys)
+	if err := rb.Build(keys); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	errc := make(chan error, numGoroutines)
+	for g := 0; g < numGoroutines; g++ {
+		go func(gid int) {
+			for i := 0; i < queriesPerGoroutine; i++ {
+				key := keys[i%numKeys]
+				if !rb.Contains(key) {
+					errc <- fmt.Errorf("goroutine %d: false negative for key %q", gid, key)
+					return
+				}
+			}
+			errc <- nil
+		}(g)
+	}
+
+	for g := 0; g < numGoroutines; g++ {
+		if err := <-errc; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// =============================================================================
+// ErrConstructionFailed — sentinel value checks
+// =============================================================================
+
+func TestErrConstructionFailed_IsError(t *testing.T) {
+	// Verify that ErrConstructionFailed satisfies the error interface
+	// and has a descriptive message.
+	var err error = ErrConstructionFailed
+
+	if err.Error() == "" {
+		t.Error("ErrConstructionFailed.Error() should not be empty")
+	}
+
+	// errors.Is should work for direct comparison.
+	if !errors.Is(err, ErrConstructionFailed) {
+		t.Error("errors.Is(ErrConstructionFailed, ErrConstructionFailed) should be true")
+	}
+}

--- a/solver.go
+++ b/solver.go
@@ -1,0 +1,322 @@
+package ribbon
+
+import "math/bits"
+
+// =============================================================================
+// SOLUTION — the in-memory Ribbon filter (solution vector)
+// =============================================================================
+
+// solution holds the solved solution rows produced by back-substitution.
+//
+// After the Bander has constructed an upper-triangular banded matrix via
+// on-the-fly Gaussian elimination (paper §2), back-substitution walks the
+// matrix in reverse to compute the solution vector S. This vector IS the
+// Ribbon filter — each query hashes a key to a (start, coefficients)
+// pair, loads w consecutive solution rows, and computes the dot product
+// over GF(2) per result column.
+//
+// Memory layout:
+//
+// The solution is stored as one result row (uint8) per slot — matching
+// RocksDB's SimpleSolutionStorage. Each S[i] is a multi-bit value where
+// bit j represents the solution for result column j at slot i.
+//
+// This is a row-major layout: data[slot_index] holds all r result
+// bits for that slot. Queries iterate over w slots (the ribbon width),
+// computing a dot product per result column simultaneously via branchless
+// masking.
+//
+// Paper §3: the query for key x computes:
+//
+//	result = ⊕_{k=0}^{w-1} (c[k] ? S[s(x)+k] : 0)
+//
+// where c[k] is coefficient bit k, and S[i] is the r-bit solution row.
+// A true member satisfies result == getResultRow(hash(key)).
+//
+// [RocksDB: InMemSimpleSolution in ribbon_impl.h]
+type solution struct {
+	data       []uint8 // one result row per slot; len = numSlots + w (padded)
+	numSlots   uint32  // total number of slots from the bander
+	coeffBits  uint32  // ribbon width w (32, 64, or 128)
+	resultBits uint    // number of fingerprint bits r (e.g. 7)
+}
+
+// load returns the solution row at the given slot index.
+// Used by the query path and tests. Returns the full r-bit result row.
+func (s *solution) load(i uint32) uint8 {
+	return s.data[i]
+}
+
+// =============================================================================
+// PARITY — GF(2) dot product helpers
+// =============================================================================
+
+// parity64 returns the parity (XOR-sum) of the set bits in val.
+// Returns 0 if the number of set bits is even, 1 if odd.
+//
+// Over GF(2), the dot product of two bit-vectors a and b is:
+//
+//	parity(a & b)
+//
+// Uses math/bits.OnesCount64, which compiles to a POPCNT instruction
+// on x86-64 and a sequence of shifts on ARM64. The & 1 extracts parity.
+func parity64(val uint64) int {
+	return bits.OnesCount64(val) & 1
+}
+
+// parity128 returns the parity of the set bits in a 128-bit value.
+// Reduces to a single parity64 by XOR-folding the two halves.
+//
+// Proof: parity(hi ^ lo) = parity(hi) ^ parity(lo), which equals
+// the parity of the full 128-bit concatenation {hi, lo}.
+func parity128(val uint128) int {
+	return parity64(val.hi ^ val.lo)
+}
+
+// =============================================================================
+// BACK-SUBSTITUTION — solving the upper-triangular system
+// =============================================================================
+
+// backSubstitute solves the upper-triangular banded linear system produced
+// by the Bander, computing the solution vector S that will serve as the
+// Ribbon filter's in-memory representation.
+//
+// The resultBits parameter r specifies how many fingerprint bits are stored
+// per key (e.g. r=7 for FPR ≈ 2^(-7) ≈ 0.78%).
+//
+// Paper §2 & RocksDB SimpleBackSubst (ribbon_alg.h):
+//
+// The Bander has produced an m×m upper-triangular banded matrix where each
+// occupied row i has:
+//   - coeffRow c:  a w-bit coefficient row with c[0] = 1 (the pivot).
+//   - result   r:  the r-bit fingerprint for that equation.
+//
+// Back-substitution walks backwards from i = m-1 down to i = 0, solving
+// for each result column j independently.
+//
+// RocksDB tracks a column-major state buffer: state[j] is a CoeffRow-sized
+// shift register holding the most recent w solution bits for column j.
+// For each slot i and each result column j:
+//
+//	tmp = state[j] << 1
+//	bit = parity(tmp & c) ^ ((r >> j) & 1)
+//	tmp |= bit
+//	state[j] = tmp
+//	S[i].bit_j = bit
+//
+// This is equivalent to the scalar formulation:
+//
+//	S[i].bit_j = ((r >> j) & 1) ⊕ parity(S[i+1..i+w-1].bit_j & c[1..w-1])
+//
+// The state shift register elegantly avoids "unaligned reads" from the
+// solution array: instead of reading back from memory, we maintain a
+// sliding window of the last w bits per column in a register. The
+// left-shift makes room for the new bit at position 0.
+//
+// Width-specialised inner loops:
+//   - w≤64:  state[j] is uint64. Shift + AND + POPCNT is register-only.
+//   - w=128: state[j] is uint128. Uses the uint128.lsh/and methods.
+//
+// Memory allocation: the solution ([]uint8) is allocated once. The state
+// array is stack-allocated (r entries of CoeffRow size). The inner loop
+// is allocation-free.
+//
+// [RocksDB: SimpleBackSubst in ribbon_alg.h]
+func backSubstitute(sb *standardBander, resultBits uint) *solution {
+	numSlots := sb.numSlots
+	if numSlots == 0 {
+		return &solution{
+			data:       nil,
+			numSlots:   0,
+			coeffBits:  0,
+			resultBits: resultBits,
+		}
+	}
+
+	// Determine ribbon width from the concrete bander.
+	coeffBits := uint32(64)
+	if sb.coeffHi != nil {
+		coeffBits = 128
+	}
+
+	// Allocate one result row per slot, plus w padding slots (zero-valued)
+	// so that query can read w consecutive entries starting at any valid
+	// start position without bounds checking.
+	sol := &solution{
+		data:       make([]uint8, uint64(numSlots)+uint64(coeffBits)),
+		numSlots:   numSlots,
+		coeffBits:  coeffBits,
+		resultBits: resultBits,
+	}
+
+	// Dispatch to width-specialised back-substitution.
+	if coeffBits <= 64 {
+		backSubst64(sol, sb, numSlots, resultBits)
+	} else {
+		backSubst128(sol, sb, numSlots, resultBits)
+	}
+
+	return sol
+}
+
+// backSubst64 performs back-substitution for ribbon width w ≤ 64.
+//
+// Uses a column-major state buffer (one uint64 per result column) that
+// acts as a shift register of the last w solution bits for each column.
+// This avoids all unaligned reads from the solution array during
+// construction — the sliding window is maintained entirely in registers
+// (for small r, like r=7, the state fits in 7 general-purpose registers).
+//
+// For each slot i (reverse order) and each result column j:
+//  1. Left-shift state[j] by 1 to make room for the new bit at position 0.
+//  2. Compute: bit = parity(shifted_state & coeff) ⊕ result_bit_j.
+//  3. OR the new bit into position 0 of the shifted state.
+//  4. Store the updated state and accumulate the bit into the solution row.
+//
+// The left-shift naturally discards bits older than w positions because
+// we're using a uint64 for w≤64. Bits that "fall off" the top are
+// irrelevant — they correspond to slots more than w positions ahead,
+// which can never appear in any coefficient row's reach.
+//
+// Uses the well-tested getSlot() accessor rather than direct array access.
+// The compiler inlines getSlot (cost 32) and dead-code-eliminates the
+// coeffHi nil branch since it's unreachable in the w≤64 path.
+func backSubst64(sol *solution, sb *standardBander, numSlots uint32, resultBits uint) {
+	// Clamp resultBits to the maximum supported by uint8 result rows.
+	// This lets the compiler prove j < 8 for state[j] bounds elimination.
+	if resultBits > 8 {
+		resultBits = 8
+	}
+
+	data := sol.data[:numSlots]
+
+	// Column-major state: state[j] holds the last w bits of column j.
+	var state [8]uint64
+
+	for i := int64(numSlots) - 1; i >= 0; i-- {
+		slot := sb.getSlot(uint32(i))
+		c := slot.coeffRow.lo
+		r := slot.result
+
+		var sr uint8
+
+		for j := uint(0); j < resultBits; j++ {
+			tmp := state[j] << 1
+
+			bit := parity64(tmp&c) ^ int((r>>j)&1)
+			tmp |= uint64(bit)
+
+			state[j] = tmp
+			sr |= uint8(bit) << j
+		}
+
+		data[i] = sr
+	}
+}
+
+// backSubst128 performs back-substitution for ribbon width w = 128.
+//
+// Identical algorithm to backSubst64 but uses uint128 for the state
+// registers and coefficient rows. Each shift register is 128 bits wide,
+// matching the ribbon width.
+//
+// Uses getSlot() for data access (clean, tested accessor) but manually
+// inlines the constant-1 shift and parity128 in the inner loop. The
+// uint128.lsh() method has a 4-branch dispatch (n>=128, n>=64, n==0, else)
+// that the compiler can't constant-fold after inlining, costing ~27%
+// extra per slot. For the constant n=1, we expand to 2 shifts + 1 OR.
+func backSubst128(sol *solution, sb *standardBander, numSlots uint32, resultBits uint) {
+	if resultBits > 8 {
+		resultBits = 8
+	}
+
+	data := sol.data[:numSlots]
+
+	var state [8]uint128
+
+	for i := int64(numSlots) - 1; i >= 0; i-- {
+		slot := sb.getSlot(uint32(i))
+		cLo := slot.coeffRow.lo
+		cHi := slot.coeffRow.hi
+		r := slot.result
+
+		var sr uint8
+
+		for j := uint(0); j < resultBits; j++ {
+			// Manual lsh(1): avoids the 4-branch dispatch in uint128.lsh().
+			sj := state[j]
+			tmpLo := sj.lo << 1
+			tmpHi := (sj.hi << 1) | (sj.lo >> 63)
+
+			// Inline parity128(tmp.and(c)): 2 ANDs + 1 XOR + POPCNT.
+			bit := bits.OnesCount64((tmpHi&cHi)^(tmpLo&cLo))&1 ^ int((r>>j)&1)
+
+			tmpLo |= uint64(bit)
+
+			state[j] = uint128{hi: tmpHi, lo: tmpLo}
+			sr |= uint8(bit) << j
+		}
+
+		data[i] = sr
+	}
+}
+
+// =============================================================================
+// QUERY — verifying membership against the solution vector
+// =============================================================================
+
+// query computes the GF(2) dot product of the solution vector S with the
+// coefficient row c, starting at position `start`. Returns the r-bit
+// result row for comparison against the expected fingerprint.
+//
+// For a key that was in the original set:
+//
+//	query(start, coeffRow) == expectedResult
+//
+// For a key NOT in the set, this holds with probability 2^(-r).
+//
+// This is the "filter query" operation: hash the key to get
+// (start, coeffRow, expectedResult), compute query(start, coeffRow),
+// and compare with expectedResult.
+//
+// The query iterates over set bits in the coefficient row using
+// TrailingZeros + clear-lowest-bit (TZCNT + BLSR on x86, RBIT+CLZ on
+// ARM64). For each set bit k, it XORs S[start+k] into the result.
+//
+// Optimisations:
+//   - Single function body: processes lo and hi halves sequentially,
+//     eliminating the dispatch overhead of separate query64/query128
+//     methods. For w=64, coeffRow.hi is always 0, so the second loop
+//     is a zero-iteration no-op.
+//   - Pre-sliced data: s.data[start:] is sliced once at the top,
+//     converting per-iteration bounds checks (start + lsb < len) into
+//     a single slice bounds check. The solution's w-padding bytes
+//     guarantee start + w ≤ len(s.data).
+//   - Skip-zero iteration: only set bits are visited via TrailingZeros
+//   - clear-lowest-bit, halving the iteration count vs a naive 0..w
+//     loop (~32 iterations for w=64 random coefficients instead of 64).
+//
+// [RocksDB: SimpleQueryHelper in ribbon_alg.h]
+func (s *solution) query(start uint32, coeffRow uint128) uint8 {
+	var result uint8
+	// Single bounds check for the entire query window.
+	data := s.data[start:]
+	_ = data[127] // BCE proof: len(data) >= 128, eliminates per-iteration checks below.
+
+	// Process the lower 64 bits (positions 0..63).
+	lo := coeffRow.lo
+	for lo != 0 {
+		result ^= data[bits.TrailingZeros64(lo)&63]
+		lo &= lo - 1
+	}
+
+	// Process the upper 64 bits (positions 64..127).
+	// For w<=64, coeffRow.hi is always 0, making this a zero-iteration loop.
+	hi := coeffRow.hi
+	for hi != 0 {
+		result ^= data[64+bits.TrailingZeros64(hi)&63]
+		hi &= hi - 1
+	}
+
+	return result
+}

--- a/solver_bench_test.go
+++ b/solver_bench_test.go
@@ -1,0 +1,467 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// Benchmarks — back-substitution (solver) performance
+//
+// BackSubstitute walks the upper-triangular banded matrix in reverse,
+// computing the solution vector S that IS the Ribbon filter. The hot path
+// is the column-major state-register shift, parity (POPCNT), and
+// per-column bit accumulation.
+//
+// Query computes the GF(2) dot product of the solution vector with a
+// coefficient row — the per-key membership test. It iterates over set
+// bits using TrailingZeros (TZCNT/BSF) and XORs solution rows.
+//
+// We benchmark:
+//   1. BackSubstitute — full back-substitution on large Banders.
+//   2. BackSubstitute by resultBits — how r affects construction cost.
+//   3. Query — per-key membership query cost.
+//   4. Query throughput — batch query over many keys, keys/op metric.
+//   5. Full pipeline throughput — band + solve + query end-to-end.
+//   6. Solution memory — bytes per slot for different configurations.
+//
+// Each is measured across ribbon widths (64/128) to surface width-dependent
+// costs — primarily the uint128 overhead in the state-register inner loop.
+// =============================================================================
+
+// benchBuildBander creates a fully-banded standardBander with numKeys keys.
+// Returns the bander, hasher (with the successful seed set), and key hashes.
+// Panics if banding fails after 200 seeds (shouldn't happen with generous sizing).
+func benchBuildBander(w uint32, numKeys int) (*standardBander, *standardHasher, []uint64) {
+	numStarts := uint32(float64(numKeys) * 1.1)
+	numSlots := numStarts + w - 1
+	h := newStandardHasher(w, numStarts, 7, true)
+
+	hashes := make([]uint64, numKeys)
+	for i := 0; i < numKeys; i++ {
+		hashes[i] = h.keyHash([]byte(fmt.Sprintf("bench_solver_key_%d", i)))
+	}
+
+	for seed := uint32(0); seed < 200; seed++ {
+		h.setOrdinalSeed(seed)
+		bd := newStandardBander(numSlots, w, true)
+
+		hrs := make([]hashResult, numKeys)
+		for i, kh := range hashes {
+			hrs[i] = h.derive(kh)
+		}
+
+		if bd.AddRange(hrs) {
+			return bd, h, hashes
+		}
+	}
+	panic("benchBuildBander: banding failed for all 200 seeds")
+}
+
+// benchBuildSolution builds a bander and solves it, returning the solution
+// and pre-computed query parameters. Used by query benchmarks to isolate
+// query cost from construction cost.
+func benchBuildSolution(w uint32, numKeys int) (*solution, []benchQueryParam) {
+	bd, h, hashes := benchBuildBander(w, numKeys)
+	sol := backSubstitute(bd, 7)
+
+	params := make([]benchQueryParam, numKeys)
+	for i, kh := range hashes {
+		rh := h.rehash(kh)
+		params[i] = benchQueryParam{
+			start:    h.getStart(rh),
+			coeffRow: h.getCoeffRow(rh),
+		}
+	}
+	return sol, params
+}
+
+type benchQueryParam struct {
+	start    uint32
+	coeffRow uint128
+}
+
+// ---------------------------------------------------------------------------
+// 1. BackSubstitute — full back-substitution on a large Bander
+//
+// Measures the complete back-substitution cost: allocating the solution
+// vector, iterating numSlots times in reverse, maintaining r column-major
+// state registers, and accumulating the multi-bit result per slot.
+//
+// The dominant cost is r × (shift + AND + POPCNT + XOR + OR) per occupied
+// slot. For r=7 and w=64, this is ~50 instructions per slot, all
+// register-to-register. The inner loop accesses the bander's SoA arrays
+// sequentially (backwards), giving excellent cache behaviour.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   Keys      ns/op       B/op      allocs/op
+//   ─────   ──────    ──────────  ────────   ─────────
+//   w=64    1,000      12,451     1,328      2
+//   w=64    10,000    116,133     12,336     2
+//   w=64    100,000 1,160,954    114,736     2
+//   w=128   1,000      15,370     1,456      2
+//   w=128   10,000    137,531     12,336     2
+//   w=128   100,000 1,365,698    114,737     2
+//
+// Key observations:
+//   • Only 2 allocations regardless of scale — one for the Solution struct,
+//     one for the []uint8 data slice. The r=7 column-major state array
+//     ([8]uint64 or [8]uint128) lives entirely on the stack.
+//   • Scales linearly with numSlots: ~11.6 ns/slot for w=64, ~13.8 ns/slot
+//     for w=128. Direct SoA access (no interface dispatch or bandingSlot
+//     struct construction) keeps the inner loop cache-friendly.
+//   • The uint128 path is ~19% more expensive than uint64, down from ~34%
+//     before manual lsh(1) inlining and branchless bit insertion.
+//   • Memory: ~1.1 B/key (one uint8 per slot plus w padding bytes).
+//     Compact — a 1M-key filter's solution occupies ~1.1 MB.
+//   • 100K-key w=64 back-substitution takes ~1.2 ms — fast enough that
+//     construction is dominated by banding, not solving.
+// ---------------------------------------------------------------------------
+
+func BenchmarkBackSubstitute(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		for _, numKeys := range []int{1000, 10000, 100000} {
+			name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+			b.Run(name, func(b *testing.B) {
+				bd, _, _ := benchBuildBander(w, numKeys)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink *solution
+				for i := 0; i < b.N; i++ {
+					sink = backSubstitute(bd, 7)
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. BackSubstitute by resultBits — impact of r on construction cost
+//
+// The inner loop of back-substitution iterates over r result columns per
+// slot. Increasing r linearly increases the work: each column requires
+// one shift + AND + POPCNT + XOR + OR sequence. This benchmark quantifies
+// that linear scaling.
+//
+// Reference results (Apple M3 Pro, Go 1.25, w=64, n=10000, -benchtime=2s):
+//
+//   r-bits   ns/op       ns/slot    allocs/op
+//   ──────   ──────────  ────────   ─────────
+//   r=1       87,924      7.95      2
+//   r=4       90,244      8.16      2
+//   r=7      117,019     10.58      2
+//   r=8      130,524     11.80      2
+//
+// Key observations:
+//   • Cost scales sub-linearly with r: going from r=1 to r=8 is only
+//     ~1.49× more expensive (not 8×). The fixed cost of loading each
+//     slot's coeffRow and result from the SoA arrays dominates at low r.
+//   • Incremental cost per column: (130,524 - 87,924) / 7 ≈ 6,086 ns
+//     per additional column over 11,063 slots ≈ 0.55 ns per (slot, column).
+//     This is the pure shift + AND + POPCNT + XOR + OR sequence cost.
+//   • r=7 (the default) is only ~33% more expensive than r=1 while
+//     providing 128× better false-positive rate (2^(-7) vs 2^(-1)).
+//   • Memory is identical for all r values — the []uint8 stores up to
+//     8 result bits per slot regardless.
+// ---------------------------------------------------------------------------
+
+func BenchmarkBackSubstituteByResultBits(b *testing.B) {
+	const numKeys = 10000
+	w := uint32(64)
+	numStarts := uint32(float64(numKeys) * 1.1)
+	numSlots := numStarts + w - 1
+
+	// Build a bander once (result bits don't affect banding).
+	h := newStandardHasher(w, numStarts, 7, true)
+	hashes := make([]uint64, numKeys)
+	for i := 0; i < numKeys; i++ {
+		hashes[i] = h.keyHash([]byte(fmt.Sprintf("bench_rbits_key_%d", i)))
+	}
+	var bd *standardBander
+	for seed := uint32(0); seed < 200; seed++ {
+		h.setOrdinalSeed(seed)
+		bd = newStandardBander(numSlots, w, true)
+		hrs := make([]hashResult, numKeys)
+		for i, kh := range hashes {
+			hrs[i] = h.derive(kh)
+		}
+		if bd.AddRange(hrs) {
+			break
+		}
+	}
+
+	for _, r := range []uint{1, 4, 7, 8} {
+		name := fmt.Sprintf("r=%d", r)
+		b.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink *solution
+			for i := 0; i < b.N; i++ {
+				sink = backSubstitute(bd, r)
+			}
+			_ = sink
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(numSlots), "ns/slot")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Query — per-key membership query cost
+//
+// Measures the per-key query cost after the filter is built. This is the
+// runtime cost of using the Ribbon filter for membership testing.
+//
+// The query iterates over set bits in the coefficient row (using
+// TrailingZeros to skip zeros), XORing solution rows. For a typical
+// w=64 coefficient row with ~32 set bits, this is ~32 XORs + ~32 TZCNT.
+// For w=128, both lo and hi halves are processed sequentially.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   ns/op   allocs/op
+//   ─────   ─────   ─────────
+//   w=64    37.00   0
+//   w=128   66.84   0
+//
+// Key observations:
+//   • Zero allocations — the query is pure register + array indexing work.
+//     Query inlines at cost 69 (budget 80), so callers pay zero call overhead.
+//   • w=64: ~37 ns/query ≈ 27M queries/sec. A random w=64 coefficient row
+//     has ~32 set bits on average, so the loop body executes ~32 times:
+//     one TZCNT + one XOR + one bit-clear per iteration ≈ 1.2 ns per set bit.
+//   • w=128: ~67 ns/query ≈ 15M queries/sec. ~1.8× the w=64 cost,
+//     consistent with ~64 set bits in 128-bit coefficient rows.
+//   • The skip-zero optimisation (iterating only over set bits via
+//     TrailingZeros + clear-lowest-bit) avoids touching the ~50% of zero
+//     coefficient bits, halving the iteration count vs a naive 0..w loop.
+//   • Per-iteration bounds checks eliminated via pre-sliced data window
+//     and & 63 index masking, reducing overhead from ~32 checks to 1.
+// ---------------------------------------------------------------------------
+
+func BenchmarkQuery(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 10000
+			sol, params := benchBuildSolution(w, numKeys)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink uint8
+			for i := 0; i < b.N; i++ {
+				p := params[i%numKeys]
+				sink = sol.query(p.start, p.coeffRow)
+			}
+			_ = sink
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Query throughput — batch query, keys/op metric
+//
+// Simulates a realistic query workload: querying all keys in a tight loop.
+// Reports wall-clock time per batch and throughput in keys/op, matching
+// the style of BenchmarkDeriveThroughput in hash_bench_test.go.
+//
+// This represents the end-to-end filter lookup throughput (excluding the
+// hash computation, which is benchmarked separately in hash_bench_test.go).
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   ns/op       keys/op   ~keys/sec    allocs/op
+//   ─────   ──────────  ───────   ──────────   ─────────
+//   w=64    3,255,685   100,000   ~30.7M       0
+//   w=128   6,232,455   100,000   ~16.0M       0
+//
+// Key observations:
+//   • ~32.6 ns/key for w=64 in batch — slightly faster than the per-call
+//     37 ns due to branch predictor warming over the tight loop.
+//   • ~62.3 ns/key for w=128 in batch — ~1.91× the w=64 cost, matching
+//     the coefficient row width ratio.
+//   • 100K queries complete in 3.3 ms (w=64) or 6.2 ms (w=128), meaning
+//     a 1M-key filter can process a 100K-query batch in under 63 ms.
+//   • Zero allocations across the entire 100K-key batch.
+// ---------------------------------------------------------------------------
+
+func BenchmarkQueryThroughput(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 100_000
+			sol, params := benchBuildSolution(w, numKeys)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink uint8
+			for i := 0; i < b.N; i++ {
+				for _, p := range params {
+					sink = sol.query(p.start, p.coeffRow)
+				}
+			}
+			_ = sink
+			b.ReportMetric(float64(numKeys), "keys/op")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Full pipeline throughput — band + solve + query end-to-end
+//
+// Measures the combined cost of banding all keys (AddRange), solving
+// (BackSubstitute), and querying all keys. This is the most realistic
+// benchmark: it captures the total cost of building and verifying a
+// Ribbon filter.
+//
+// The derive() cost is excluded (benchmarked in hash_bench_test.go);
+// hashResult values are pre-computed.
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   Keys     ns/op         keys/op   ~keys/sec     allocs/op
+//   ─────   ──────   ──────────    ───────   ──────────    ─────────
+//   w=64    10,000   522,953       10,000    ~19.1M        4
+//   w=128   10,000   893,028       10,000    ~11.2M        5
+//
+// Key observations:
+//   • End-to-end cost breakdown for w=64 (523 µs total, 10K keys):
+//     - Banding (AddRange):   ~53 µs (benchmarked separately: ~5.3 ns/key)
+//     - BackSubstitute:      ~116 µs (~11.6 ns/slot, 10K slots)
+//     - Query (10K keys):    ~370 µs (~37 ns/key)
+//     Query dominates at ~71% of total cost — the random-access pattern
+//     of reading solution rows incurs more cache misses than the
+//     sequential backwards pass of back-substitution.
+//   • w=128 is ~1.7× slower end-to-end (893 vs 523 µs), reflecting the
+//     wider coefficient rows in both back-substitution and query.
+//   • 4 allocations for w=64 (bander: coeffLo + result + struct;
+//     solution: struct + data). 5 for w=128 (adds coeffHi).
+//     One fewer than pre-optimisation due to escape analysis improvements.
+//   • ~19.1M keys/sec (w=64) means building and fully verifying a
+//     10K-key filter takes ~0.52 ms per seed attempt.
+// ---------------------------------------------------------------------------
+
+func BenchmarkFullPipelineThroughput(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		b.Run(name, func(b *testing.B) {
+			const numKeys = 10000
+			numStarts := uint32(float64(numKeys) * 1.2)
+			numSlots := numStarts + w - 1
+			h := newStandardHasher(w, numStarts, 7, true)
+
+			hashes := make([]uint64, numKeys)
+			for i := 0; i < numKeys; i++ {
+				hashes[i] = h.keyHash([]byte(fmt.Sprintf("bench_pipeline_key_%d", i)))
+			}
+
+			// Find a working seed.
+			var workingSeed uint32
+			for seed := uint32(0); seed < 200; seed++ {
+				h.setOrdinalSeed(seed)
+				bd := newStandardBander(numSlots, w, true)
+				hrs := make([]hashResult, numKeys)
+				for i, kh := range hashes {
+					hrs[i] = h.derive(kh)
+				}
+				if bd.AddRange(hrs) {
+					workingSeed = seed
+					break
+				}
+			}
+
+			// Pre-compute hashResults for the working seed.
+			h.setOrdinalSeed(workingSeed)
+			hrs := make([]hashResult, numKeys)
+			for i, kh := range hashes {
+				hrs[i] = h.derive(kh)
+			}
+
+			// Pre-compute query parameters.
+			type qp struct {
+				start    uint32
+				coeffRow uint128
+			}
+			params := make([]qp, numKeys)
+			for i, kh := range hashes {
+				rh := h.rehash(kh)
+				params[i] = qp{
+					start:    h.getStart(rh),
+					coeffRow: h.getCoeffRow(rh),
+				}
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var sink uint8
+			for i := 0; i < b.N; i++ {
+				// Band.
+				bd := newStandardBander(numSlots, w, true)
+				bd.AddRange(hrs)
+				// Solve.
+				sol := backSubstitute(bd, 7)
+				// Query all keys.
+				for _, p := range params {
+					sink = sol.query(p.start, p.coeffRow)
+				}
+			}
+			_ = sink
+			b.ReportMetric(float64(numKeys), "keys/op")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Solution memory — bytes per slot
+//
+// Reports the memory footprint of the Solution for different widths and
+// key counts. The solution stores one uint8 per slot plus w padding bytes,
+// so memory = numSlots + w bytes (plus 40 bytes of struct overhead).
+//
+// Reference results (Apple M3 Pro, Go 1.25, -benchtime=2s):
+//
+//   Width   Keys      B/op      B/key   allocs/op
+//   ─────   ──────    ───────   ─────   ─────────
+//   w=64    10,000     12,336   1.113   2
+//   w=64    100,000   114,736   1.101   2
+//   w=128   10,000     12,336   1.125   2
+//   w=128   100,000   114,739   1.103   2
+//
+// Key observations:
+//   • ~1.1 bytes per key — the solution stores one uint8 per slot, and
+//     numSlots ≈ 1.1 × numKeys (the 10% overhead from the banding pass
+//     sizing). The w padding bytes are negligible at scale.
+//   • Width has negligible effect on memory: the difference between w=64
+//     and w=128 is only the w padding bytes (64 vs 128 bytes), which
+//     vanishes as numKeys grows.
+//   • Extremely compact: a 1M-key Ribbon filter occupies ~1.1 MB —
+//     comparable to a Bloom filter at ~1.2 bytes/key for the same FPR,
+//     but with the added benefit of exact r-bit fingerprints.
+//   • Always exactly 2 allocations: the Solution struct and the []uint8
+//     data slice. No per-slot or per-column allocations.
+// ---------------------------------------------------------------------------
+
+func BenchmarkSolutionMemory(b *testing.B) {
+	for _, w := range []uint32{64, 128} {
+		for _, numKeys := range []int{10000, 100000} {
+			name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+			b.Run(name, func(b *testing.B) {
+				bd, _, _ := benchBuildBander(w, numKeys)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var sink *solution
+				for i := 0; i < b.N; i++ {
+					sink = backSubstitute(bd, 7)
+				}
+				_ = sink
+				// Report bytes-per-key for the solution data only.
+				numSlots := bd.getNumSlots()
+				bytesPerKey := float64(uint64(numSlots)+uint64(w)) / float64(numKeys)
+				b.ReportMetric(bytesPerKey, "B/key")
+			})
+		}
+	}
+}

--- a/solver_test.go
+++ b/solver_test.go
@@ -1,0 +1,776 @@
+package ribbon
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+// makeBanderFromSlots creates a standardBander with pre-set slot data,
+// bypassing the normal Add() path. This lets us construct hand-crafted
+// upper-triangular matrices with known mathematical solutions.
+func makeBanderFromSlots(numSlots, coeffBits uint32, slots []bandingSlot) *standardBander {
+	b := newStandardBander(numSlots, coeffBits, true)
+	for i, s := range slots {
+		b.coeffLo[i] = s.coeffRow.lo
+		if b.coeffHi != nil {
+			b.coeffHi[i] = s.coeffRow.hi
+		}
+		b.result[i] = s.result
+	}
+	return b
+}
+
+// =============================================================================
+// HAND-CRAFTED MATRIX TESTS — known mathematical solutions
+//
+// These tests use resultBits=1 for simplicity: each result is a single
+// bit, and each S[i] is either 0x00 or 0x01. This makes the math
+// easy to verify by hand.
+// =============================================================================
+
+func TestBackSubstitute_TrivialSingleSlot(t *testing.T) {
+	// Simplest case: 1 slot with coefficient = 1, result = 1.
+	// Equation: 1 · S[0] = 1  →  S[0] = 1.
+	slots := make([]bandingSlot, 64)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 1}, result: 1}
+	// All other slots are empty (coeffRow = 0), so S[1..63] = 0.
+	b := makeBanderFromSlots(64, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(0) != 1 {
+		t.Errorf("S[0] = %d, want 1", sol.load(0))
+	}
+	// All other rows should be 0.
+	for i := uint32(1); i < 64; i++ {
+		if sol.load(i) != 0 {
+			t.Errorf("S[%d] = %d, want 0", i, sol.load(i))
+		}
+	}
+}
+
+func TestBackSubstitute_TrivialSingleSlotZeroResult(t *testing.T) {
+	// Equation: 1 · S[0] = 0  →  S[0] = 0.
+	slots := make([]bandingSlot, 64)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 1}, result: 0}
+	b := makeBanderFromSlots(64, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(0) != 0 {
+		t.Errorf("S[0] = %d, want 0", sol.load(0))
+	}
+}
+
+func TestBackSubstitute_TwoSlots_WithDependency(t *testing.T) {
+	// 2-slot system (numSlots=65, w=64):
+	//
+	// Slot 0: coeff = 0b11 (bits 0 and 1 set), result = 1
+	//   Equation: S[0] ⊕ S[1] = 1
+	//
+	// Slot 1: coeff = 0b1 (bit 0 set), result = 0
+	//   Equation: S[1] = 0
+	//
+	// Back-substitution (reverse order):
+	//   i=1: S[1] = 0 (from equation: 1·S[1] = 0)
+	//   i=0: S[0] = 1 ⊕ parity(state & 0b11)
+	//     state[0] after i=1: shifted=0, bit=0, state=0
+	//     At i=0: tmp = state<<1 = 0
+	//       bit = parity(0 & 0b11) ^ (1 & 1) = 0 ^ 1 = 1
+	//       state = 0 | 1 = 1
+	//       S[0] = 1  ✓
+	numSlots := uint32(65) // 2 starts + 64 - 1
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 0b11}, result: 1}
+	slots[1] = bandingSlot{coeffRow: uint128{lo: 0b1}, result: 0}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(0) != 1 {
+		t.Errorf("S[0] = %d, want 1", sol.load(0))
+	}
+	if sol.load(1) != 0 {
+		t.Errorf("S[1] = %d, want 0", sol.load(1))
+	}
+}
+
+func TestBackSubstitute_ThreeSlots_ChainDependency(t *testing.T) {
+	// 3-slot chain:
+	//
+	// Slot 0: coeff = 0b111 (bits 0,1,2), result = 0
+	//   Equation: S[0] ⊕ S[1] ⊕ S[2] = 0
+	//
+	// Slot 1: coeff = 0b11 (bits 0,1), result = 1
+	//   Equation: S[1] ⊕ S[2] = 1
+	//
+	// Slot 2: coeff = 0b1 (bit 0), result = 1
+	//   Equation: S[2] = 1
+	//
+	// Back-substitution (column j=0, single result bit):
+	//   i=2: tmp=0, bit=parity(0 & 1) ^ 1 = 1, state=1       → S[2]=1
+	//   i=1: tmp=1<<1=2, bit=parity(2 & 3) ^ 1 = parity(2)^1 = 1^1 = 0
+	//     state=2|0=2  → S[1]=0
+	//   i=0: tmp=2<<1=4, bit=parity(4 & 7) ^ 0 = parity(4)^0 = 1
+	//     state=4|1=5  → S[0]=1
+	numSlots := uint32(66) // 3 starts + 64 - 1
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 0b111}, result: 0}
+	slots[1] = bandingSlot{coeffRow: uint128{lo: 0b11}, result: 1}
+	slots[2] = bandingSlot{coeffRow: uint128{lo: 0b1}, result: 1}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	want := []uint8{1, 0, 1}
+	for i, w := range want {
+		if sol.load(uint32(i)) != w {
+			t.Errorf("S[%d] = %d, want %d", i, sol.load(uint32(i)), w)
+		}
+	}
+}
+
+func TestBackSubstitute_AllEmpty(t *testing.T) {
+	// All slots empty → all free variables → S = all zeros.
+	numSlots := uint32(128)
+	slots := make([]bandingSlot, numSlots)
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	for i := uint32(0); i < numSlots; i++ {
+		if sol.load(i) != 0 {
+			t.Errorf("S[%d] = %d, want 0 (all-empty matrix)", i, sol.load(i))
+		}
+	}
+}
+
+func TestBackSubstitute_AllOccupied_Identity(t *testing.T) {
+	// Every slot occupied with coefficient = 1 (identity-like).
+	// Equation i: S[i] = result[i].
+	// The solution is simply the result vector.
+	numSlots := uint32(70)
+	slots := make([]bandingSlot, numSlots)
+	for i := uint32(0); i < numSlots; i++ {
+		// Alternate results: 0, 1, 0, 1, …
+		slots[i] = bandingSlot{coeffRow: uint128{lo: 1}, result: uint8(i & 1)}
+	}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	for i := uint32(0); i < numSlots; i++ {
+		want := uint8(i & 1)
+		if sol.load(i) != want {
+			t.Errorf("S[%d] = %d, want %d", i, sol.load(i), want)
+		}
+	}
+}
+
+func TestBackSubstitute_SparseMatrix(t *testing.T) {
+	// Occupied slots interspersed with empty slots.
+	// Slots 0,2,4 are occupied; slots 1,3,5+ are empty (free → 0).
+	//
+	// Slot 4: coeff = 1, result = 1  →  S[4] = 1
+	// Slot 3: empty                  →  S[3] = 0
+	// Slot 2: coeff = 0b101, result = 0
+	//   Back-subst state after slots 4,3:
+	//     After i=4: state = 1 (bit 0 = S[4] = 1)
+	//     After i=3: state = 1<<1 = 2 (shifted, bit = parity(2&0)^0 = 0)
+	//       state = 2 | 0 = 2
+	//     At i=2: tmp = 2<<1 = 4
+	//       bit = parity(4 & 0b101) ^ (0 & 1) = parity(4 & 5) ^ 0
+	//            = parity(4) ^ 0 = 1
+	//       state = 4 | 1 = 5     → S[2] = 1
+	// Slot 1: empty → S[1] = 0
+	//     After i=1: tmp = 5<<1 = 10, bit = parity(10&0)^0 = 0, state=10
+	// Slot 0: coeff = 0b10101, result = 1
+	//     At i=0: tmp = 10<<1 = 20
+	//       bit = parity(20 & 0b10101) ^ (1 & 1)
+	//            = parity(20 & 21) ^ 1 = parity(20) ^ 1 = 1 ^ 1 = 0
+	//       → S[0] = 0
+	//
+	// Wait, let me re-check. 20 = 0b10100, 0b10101 = 21.
+	// 20 & 21 = 0b10100 = 20. parity(20) = parity(0b10100) = 2 bits → 0.
+	// bit = 0 ^ 1 = 1. → S[0] = 1.
+	numSlots := uint32(68) // 5 starts + 64 - 1
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 0b10101}, result: 1}
+	slots[2] = bandingSlot{coeffRow: uint128{lo: 0b101}, result: 0}
+	slots[4] = bandingSlot{coeffRow: uint128{lo: 0b1}, result: 1}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	want := map[uint32]uint8{0: 1, 1: 0, 2: 1, 3: 0, 4: 1}
+	for idx, w := range want {
+		if sol.load(idx) != w {
+			t.Errorf("S[%d] = %d, want %d", idx, sol.load(idx), w)
+		}
+	}
+}
+
+// =============================================================================
+// MULTI-BIT RESULT TESTS — verifying multi-column back-substitution
+// =============================================================================
+
+func TestBackSubstitute_MultiBitResult(t *testing.T) {
+	// 2-bit result: each slot stores a 2-bit value.
+	// resultBits = 2.
+	//
+	// Slot 0: coeff = 0b11, result = 0b10 (decimal 2)
+	//   Equations (per column):
+	//     col 0: S[0].bit0 ⊕ S[1].bit0 = 0
+	//     col 1: S[0].bit1 ⊕ S[1].bit1 = 1
+	//
+	// Slot 1: coeff = 0b1, result = 0b11 (decimal 3)
+	//   Equations:
+	//     col 0: S[1].bit0 = 1
+	//     col 1: S[1].bit1 = 1
+	//
+	// Back-substitution:
+	//   i=1: For each column j:
+	//     j=0: tmp=0, bit=parity(0&1)^(3>>0&1)=0^1=1 → S[1].bit0=1
+	//     j=1: tmp=0, bit=parity(0&1)^(3>>1&1)=0^1=1 → S[1].bit1=1
+	//     S[1] = 0b11 = 3
+	//   i=0:
+	//     j=0: tmp=1<<1=2, bit=parity(2&3)^(2>>0&1)=parity(2)^0=1^0=1 → S[0].bit0=1
+	//     j=1: tmp=1<<1=2, bit=parity(2&3)^(2>>1&1)=parity(2)^1=1^1=0 → S[0].bit1=0
+	//     S[0] = 0b01 = 1
+	//
+	// Verify: slot 0: S[0]⊕S[1] per column:
+	//   col 0: 1⊕1 = 0 = result bit 0 ✓
+	//   col 1: 0⊕1 = 1 = result bit 1 ✓
+	numSlots := uint32(65)
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 0b11}, result: 2}
+	slots[1] = bandingSlot{coeffRow: uint128{lo: 0b1}, result: 3}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 2)
+
+	if sol.load(0) != 1 {
+		t.Errorf("S[0] = %d, want 1", sol.load(0))
+	}
+	if sol.load(1) != 3 {
+		t.Errorf("S[1] = %d, want 3", sol.load(1))
+	}
+}
+
+func TestBackSubstitute_MultiBitResult_7Bits(t *testing.T) {
+	// 7-bit result (the typical case): single slot.
+	// Slot 0: coeff = 1, result = 0x5A (0b1011010 = 90)
+	// Since it's just the identity: S[0] = result = 90.
+	numSlots := uint32(64)
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 1}, result: 0x5A}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 7)
+
+	if sol.load(0) != 0x5A {
+		t.Errorf("S[0] = 0x%02x, want 0x5A", sol.load(0))
+	}
+}
+
+// =============================================================================
+// BOUNDARY ALIGNMENT TESTS
+// =============================================================================
+
+func TestBackSubstitute_StatePropagation_AcrossEmptySlots(t *testing.T) {
+	// Verifies that the state shift register correctly propagates
+	// through empty slots (where the state still shifts but no bit
+	// is extracted from the result).
+	//
+	// Slot 127: coeff = 1, result = 1  →  S[127] = 1
+	// Slots 64-126: all empty
+	// Slot 63: coeff = 0b11 (bits 0,1), result = 0
+	//   The state for column 0 at slot 63 has been shifted 64 times
+	//   since slot 127 (through 64 empty slots). For w=64, the bit
+	//   from slot 127 has shifted to position 64, which falls off
+	//   the 64-bit register. So state = 0 at slot 63.
+	//   bit = parity(0 & 0b11) ^ 0 = 0  → S[63] = 0
+	numSlots := uint32(192)
+	slots := make([]bandingSlot, numSlots)
+	slots[127] = bandingSlot{coeffRow: uint128{lo: 1}, result: 1}
+	slots[63] = bandingSlot{coeffRow: uint128{lo: 0b11}, result: 0}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(127) != 1 {
+		t.Errorf("S[127] = %d, want 1", sol.load(127))
+	}
+	if sol.load(63) != 0 {
+		t.Errorf("S[63] = %d, want 0 (bit fell off the 64-bit window)", sol.load(63))
+	}
+}
+
+func TestBackSubstitute_StatePropagation_WithinWindow(t *testing.T) {
+	// Slot 64: coeff = 1, result = 1  → S[64] = 1
+	// Slot 60: coeff = 0b10001 (bits 0 and 4), result = 0
+	//   At slot 60, the state has been shifted 4 times since slot 64.
+	//   state has bit 4 = S[64] = 1 (within the 64-bit window).
+	//   tmp = state<<1 (now bit 5)
+	//   bit = parity(tmp & 0b10001) ^ 0
+	//       = parity(tmp & 0b10001)
+	//   tmp has bit 5 set. 0b10001 has bits 0 and 4. AND = 0. → bit = 0^0 = 0.
+	//
+	//   Hmm, let me trace more carefully.
+	//   After i=64: state[0] = 1 (bit 0 = 1).
+	//   i=63: empty. tmp=1<<1=2, bit=parity(2&0)^0=0, state=2.
+	//   i=62: empty. tmp=2<<1=4, bit=0, state=4.
+	//   i=61: empty. tmp=4<<1=8, bit=0, state=8.
+	//   i=60: tmp=8<<1=16=0b10000. bit=parity(16 & 0b10001)^0
+	//        = parity(0b10000) = 1. → S[60] = 1.
+	numSlots := uint32(192)
+	slots := make([]bandingSlot, numSlots)
+	slots[64] = bandingSlot{coeffRow: uint128{lo: 1}, result: 1}
+	slots[60] = bandingSlot{coeffRow: uint128{lo: 0b10001}, result: 0}
+	b := makeBanderFromSlots(numSlots, 64, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(64) != 1 {
+		t.Errorf("S[64] = %d, want 1", sol.load(64))
+	}
+	if sol.load(60) != 1 {
+		t.Errorf("S[60] = %d, want 1 (state propagation within window)", sol.load(60))
+	}
+}
+
+// =============================================================================
+// w=128 TESTS
+// =============================================================================
+
+func TestBackSubstitute_W128_SingleSlot(t *testing.T) {
+	numSlots := uint32(128)
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 1}, result: 1}
+	b := makeBanderFromSlots(numSlots, 128, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(0) != 1 {
+		t.Errorf("S[0] = %d, want 1", sol.load(0))
+	}
+	for i := uint32(1); i < numSlots; i++ {
+		if sol.load(i) != 0 {
+			t.Errorf("S[%d] = %d, want 0", i, sol.load(i))
+		}
+	}
+}
+
+func TestBackSubstitute_W128_CrossWordDependency(t *testing.T) {
+	// w=128 with coefficient spanning the lo half.
+	numSlots := uint32(129) // 2 starts + 128 - 1
+	slots := make([]bandingSlot, numSlots)
+	slots[0] = bandingSlot{coeffRow: uint128{lo: 0b11}, result: 0}
+	slots[1] = bandingSlot{coeffRow: uint128{lo: 0b1}, result: 1}
+	b := makeBanderFromSlots(numSlots, 128, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(0) != 1 {
+		t.Errorf("S[0] = %d, want 1", sol.load(0))
+	}
+	if sol.load(1) != 1 {
+		t.Errorf("S[1] = %d, want 1", sol.load(1))
+	}
+}
+
+func TestBackSubstitute_W128_HiHalfCoefficient(t *testing.T) {
+	// w=128 with a coefficient that has a bit set in the hi half.
+	// Slot 65: coeff = 1, result = 1  →  S[65] = 1
+	// Slot 0: coeff = {hi: 2, lo: 1}
+	//   bit 0 is the pivot (lo bit 0). bit 65 overall = hi bit 1 = value 2.
+	//   After i=65, the state for column 0 has been shifted 65 times.
+	//   At i=0: tmp = state<<1. The S[65]=1 bit is now at position 66.
+	//   We need parity(tmp & coeff). coeff bit 65 = hi bit 1. tmp bit 65 = ?
+	//
+	//   Actually with the state-register approach, let me trace:
+	//   After i=65: state=1 (bit 0).
+	//   i=64..1 (all empty): state shifts left each time.
+	//   After i=1: state has bit 64 set = {hi: 1, lo: 0}.
+	//   At i=0: tmp = state<<1 = {hi: 2, lo: 0} (bit 65).
+	//     bit = parity(tmp & coeff) ^ result
+	//         = parity({hi:2, lo:0} & {hi:2, lo:1}) ^ 0
+	//         = parity({hi:2, lo:0}) ^ 0 = 1 ^ 0 = 1
+	//     → S[0] = 1  ✓
+	numSlots := uint32(200)
+	slots := make([]bandingSlot, numSlots)
+	slots[65] = bandingSlot{coeffRow: uint128{lo: 1}, result: 1}
+	slots[0] = bandingSlot{coeffRow: uint128{hi: 2, lo: 1}, result: 0}
+	b := makeBanderFromSlots(numSlots, 128, slots)
+
+	sol := backSubstitute(b, 1)
+
+	if sol.load(65) != 1 {
+		t.Errorf("S[65] = %d, want 1", sol.load(65))
+	}
+	if sol.load(0) != 1 {
+		t.Errorf("S[0] = %d, want 1 (hi-half coefficient dependency)", sol.load(0))
+	}
+}
+
+// =============================================================================
+// PARITY TESTS
+// =============================================================================
+
+func TestParity64(t *testing.T) {
+	tests := []struct {
+		val  uint64
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{3, 0},    // 2 bits → even
+		{7, 1},    // 3 bits → odd
+		{0xFF, 0}, // 8 bits → even
+		{0xFFFF, 0},
+		{0xFFFFFFFFFFFFFFFF, 0}, // 64 bits → even
+		{0xFFFFFFFFFFFFFFFE, 1}, // 63 bits → odd
+	}
+	for _, tt := range tests {
+		got := parity64(tt.val)
+		if got != tt.want {
+			t.Errorf("parity64(0x%x) = %d, want %d", tt.val, got, tt.want)
+		}
+	}
+}
+
+func TestParity128(t *testing.T) {
+	tests := []struct {
+		val  uint128
+		want int
+	}{
+		{uint128{lo: 0, hi: 0}, 0},
+		{uint128{lo: 1, hi: 0}, 1},
+		{uint128{lo: 0, hi: 1}, 1},
+		{uint128{lo: 1, hi: 1}, 0},       // 2 bits → even
+		{uint128{lo: 3, hi: 0}, 0},       // 2 bits → even
+		{uint128{lo: 0xFF, hi: 0xFF}, 0}, // 16 bits → even
+	}
+	for _, tt := range tests {
+		got := parity128(tt.val)
+		if got != tt.want {
+			t.Errorf("parity128({lo:0x%x, hi:0x%x}) = %d, want %d",
+				tt.val.lo, tt.val.hi, got, tt.want)
+		}
+	}
+}
+
+// =============================================================================
+// QUERY TESTS — verifying the dot product against the solution vector
+// =============================================================================
+
+func TestQuery_Simple(t *testing.T) {
+	// Build a solution manually and verify queries.
+	// 2 slots, w=64, resultBits=7.
+	// S[0] = 0x5A, S[1] = 0x3C.
+	sol := &solution{
+		data:       make([]uint8, 128), // numSlots + w padding
+		numSlots:   2,
+		coeffBits:  64,
+		resultBits: 7,
+	}
+	sol.data[0] = 0x5A
+	sol.data[1] = 0x3C
+
+	// Query with coeff = 0b01 (only bit 0): result = S[0] = 0x5A.
+	got := sol.query(0, uint128{lo: 1})
+	if got != 0x5A {
+		t.Errorf("Query(0, 0b01) = 0x%02x, want 0x5A", got)
+	}
+
+	// Query with coeff = 0b10 (only bit 1): result = S[1] = 0x3C.
+	got = sol.query(0, uint128{lo: 2})
+	if got != 0x3C {
+		t.Errorf("Query(0, 0b10) = 0x%02x, want 0x3C", got)
+	}
+
+	// Query with coeff = 0b11 (both bits): result = S[0] ⊕ S[1] = 0x5A ^ 0x3C = 0x66.
+	got = sol.query(0, uint128{lo: 3})
+	if got != 0x66 {
+		t.Errorf("Query(0, 0b11) = 0x%02x, want 0x66", got)
+	}
+}
+
+func TestQuery128_Simple(t *testing.T) {
+	// w=128 query.
+	sol := &solution{
+		data:       make([]uint8, 256),
+		numSlots:   128,
+		coeffBits:  128,
+		resultBits: 7,
+	}
+	sol.data[0] = 0xAA
+	sol.data[65] = 0x55
+
+	// Coeff with bits 0 and 65 set: {hi: 2, lo: 1}.
+	got := sol.query(0, uint128{hi: 2, lo: 1})
+	if got != 0xAA^0x55 {
+		t.Errorf("Query(0, {hi:2,lo:1}) = 0x%02x, want 0x%02x", got, uint8(0xAA^0x55))
+	}
+}
+
+// =============================================================================
+// INTEGRATION TESTS — full pipeline: hash → band → solve → query
+// =============================================================================
+
+func TestBackSubstitute_FullPipeline(t *testing.T) {
+	// Full integration test: hash keys, band them, solve, and verify that
+	// querying every original key returns the correct result.
+	for _, w := range []uint32{64, 128} {
+		for _, fcao := range []bool{true, false} {
+			name := fmt.Sprintf("w=%d/fcao=%v", w, fcao)
+			t.Run(name, func(t *testing.T) {
+				const numKeys = 2000
+				const resultBits = 7
+				numStarts := uint32(float64(numKeys) * 1.1) // generous overhead
+				numSlots := numStarts + w - 1
+				h := newStandardHasher(w, numStarts, resultBits, fcao)
+
+				// Try seeds until banding succeeds.
+				var bd *standardBander
+				var hashes []uint64
+				var seed uint32
+				for seed = 0; seed < 100; seed++ {
+					h.setOrdinalSeed(seed)
+					bd = newStandardBander(numSlots, w, fcao)
+					hashes = make([]uint64, numKeys)
+					allOk := true
+					for i := 0; i < numKeys; i++ {
+						kh := h.keyHash([]byte(fmt.Sprintf("solver_test_key_%d", i)))
+						hashes[i] = kh
+						hr := h.derive(kh)
+						if !bd.Add(hr) {
+							allOk = false
+							break
+						}
+					}
+					if allOk {
+						t.Logf("banding succeeded with seed=%d", seed)
+						break
+					}
+				}
+				if seed >= 100 {
+					t.Fatal("banding failed for all seeds")
+				}
+
+				// Back-substitute.
+				sol := backSubstitute(bd, resultBits)
+
+				// Verify: for every key, Query must return the expected result.
+				for i := 0; i < numKeys; i++ {
+					rh := h.rehash(hashes[i])
+					start := h.getStart(rh)
+					coeffRow := h.getCoeffRow(rh)
+					expectedResult := h.getResultRow(rh)
+
+					gotResult := sol.query(start, coeffRow)
+					if gotResult != expectedResult {
+						t.Fatalf("key %d: Query returned %d, want %d (start=%d)",
+							i, gotResult, expectedResult, start)
+					}
+				}
+				t.Logf("all %d keys verified correctly", numKeys)
+			})
+		}
+	}
+}
+
+func TestBackSubstitute_FullPipeline_LargeScale(t *testing.T) {
+	// Larger-scale test: 10k keys, w=128, verify all queries.
+	if testing.Short() {
+		t.Skip("skipping large-scale test in short mode")
+	}
+
+	const numKeys = 10000
+	const resultBits = 7
+	w := uint32(128)
+	numStarts := uint32(float64(numKeys) * 1.05)
+	numSlots := numStarts + w - 1
+	h := newStandardHasher(w, numStarts, resultBits, true)
+
+	var bd *standardBander
+	var hashes []uint64
+	var seed uint32
+	for seed = 0; seed < 200; seed++ {
+		h.setOrdinalSeed(seed)
+		bd = newStandardBander(numSlots, w, true)
+		hashes = make([]uint64, numKeys)
+		allOk := true
+		for i := 0; i < numKeys; i++ {
+			kh := h.keyHash([]byte(fmt.Sprintf("large_key_%d", i)))
+			hashes[i] = kh
+			hr := h.derive(kh)
+			if !bd.Add(hr) {
+				allOk = false
+				break
+			}
+		}
+		if allOk {
+			break
+		}
+	}
+	if seed >= 200 {
+		t.Fatal("banding failed for all seeds")
+	}
+
+	sol := backSubstitute(bd, resultBits)
+
+	// Verify all keys.
+	for i := 0; i < numKeys; i++ {
+		rh := h.rehash(hashes[i])
+		start := h.getStart(rh)
+		coeffRow := h.getCoeffRow(rh)
+		expectedResult := h.getResultRow(rh)
+
+		gotResult := sol.query(start, coeffRow)
+		if gotResult != expectedResult {
+			t.Fatalf("key %d: Query returned %d, want %d", i, gotResult, expectedResult)
+		}
+	}
+}
+
+func TestBackSubstitute_FalsePositiveRate(t *testing.T) {
+	// Build a filter with known keys, then test that random non-member
+	// keys have an FP rate close to 2^(-r) = 2^(-7) ≈ 0.78%.
+	if testing.Short() {
+		t.Skip("skipping FP rate test in short mode")
+	}
+
+	const numKeys = 5000
+	const resultBits = 7
+	w := uint32(128)
+	numStarts := uint32(float64(numKeys) * 1.05)
+	numSlots := numStarts + w - 1
+	h := newStandardHasher(w, numStarts, resultBits, true)
+
+	var bd *standardBander
+	var seed uint32
+	for seed = 0; seed < 200; seed++ {
+		h.setOrdinalSeed(seed)
+		bd = newStandardBander(numSlots, w, true)
+		allOk := true
+		for i := 0; i < numKeys; i++ {
+			kh := h.keyHash([]byte(fmt.Sprintf("fp_key_%d", i)))
+			hr := h.derive(kh)
+			if !bd.Add(hr) {
+				allOk = false
+				break
+			}
+		}
+		if allOk {
+			break
+		}
+	}
+	if seed >= 200 {
+		t.Fatal("banding failed for all seeds")
+	}
+
+	sol := backSubstitute(bd, resultBits)
+
+	// Test non-member keys.
+	const numNonMembers = 100000
+	fps := 0
+	for i := 0; i < numNonMembers; i++ {
+		kh := h.keyHash([]byte(fmt.Sprintf("non_member_%d", i)))
+		rh := h.rehash(kh)
+		start := h.getStart(rh)
+		coeffRow := h.getCoeffRow(rh)
+		expectedResult := h.getResultRow(rh)
+
+		gotResult := sol.query(start, coeffRow)
+		if gotResult == expectedResult {
+			fps++
+		}
+	}
+
+	fpRate := float64(fps) / float64(numNonMembers)
+	expectedRate := 1.0 / float64(uint64(1)<<resultBits) // 2^(-7) ≈ 0.0078
+	t.Logf("FP rate: %.4f%% (%d / %d), expected ≈ %.4f%%",
+		fpRate*100, fps, numNonMembers, expectedRate*100)
+
+	// Allow a generous margin: within 3x of expected.
+	if fpRate > expectedRate*3 {
+		t.Errorf("FP rate %.4f%% is much higher than expected %.4f%%",
+			fpRate*100, expectedRate*100)
+	}
+	if fpRate < expectedRate*0.3 {
+		t.Errorf("FP rate %.4f%% is suspiciously low (expected ≈ %.4f%%)",
+			fpRate*100, expectedRate*100)
+	}
+}
+
+func TestBackSubstitute_ZeroSlots(t *testing.T) {
+	// Edge case: numSlots == 0.
+	b := newStandardBander(0, 64, true)
+	sol := backSubstitute(b, 7)
+	if sol.numSlots != 0 {
+		t.Errorf("numSlots = %d, want 0", sol.numSlots)
+	}
+}
+
+// =============================================================================
+// EQUATION VERIFICATION HELPER
+// =============================================================================
+
+func TestBackSubstitute_VerifyEquations(t *testing.T) {
+	// Build a small system, solve it, then directly verify that every
+	// occupied equation holds across ALL result bit columns.
+	//
+	// For each occupied slot i with coeffRow c and result r:
+	//   For each result column j:
+	//     ⊕_{k=0}^{w-1} c[k] · S[i+k].bit_j  ==  (r >> j) & 1
+	for _, w := range []uint32{64, 128} {
+		name := fmt.Sprintf("w=%d", w)
+		t.Run(name, func(t *testing.T) {
+			const numKeys = 500
+			const resultBits = 7
+			numStarts := uint32(float64(numKeys) * 1.2)
+			numSlots := numStarts + w - 1
+			h := newStandardHasher(w, numStarts, resultBits, true)
+
+			var bd *standardBander
+			for seed := uint32(0); seed < 100; seed++ {
+				h.setOrdinalSeed(seed)
+				bd = newStandardBander(numSlots, w, true)
+				allOk := true
+				for i := 0; i < numKeys; i++ {
+					kh := h.keyHash([]byte(fmt.Sprintf("verify_key_%d", i)))
+					hr := h.derive(kh)
+					if !bd.Add(hr) {
+						allOk = false
+						break
+					}
+				}
+				if allOk {
+					break
+				}
+			}
+
+			sol := backSubstitute(bd, resultBits)
+
+			// For every occupied slot, verify all result bit columns.
+			for i := uint32(0); i < numSlots; i++ {
+				slot := bd.getSlot(i)
+				if slot.coeffRow.isZero() {
+					continue
+				}
+
+				// Use Query to verify: Query(i, coeffRow) should equal result.
+				got := sol.query(i, slot.coeffRow)
+				if got != slot.result {
+					t.Fatalf("equation at slot %d failed: Query=%d, result=%d",
+						i, got, slot.result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Complete the Ribbon filter pipeline: solver, filter, builder, and public API

### Summary

This PR completes the Ribbon filter library by implementing the remaining three algorithmic layers (solver, filter, builder) and exposing a minimal, clean public API through `ribbon.go`. Combined with the hash and bander layers already on `main`, the library now implements the **full construction and query pipeline** described in Dillinger & Walzer (2021).

After this PR, users can build and query Ribbon filters end-to-end:

```go
f := ribbon.New()
f.Build(keys)           // construct
f.Contains("some-key")  // query
```

---

### What's new

**5 source files** (1,114 lines) + **6 test/benchmark files** (3,413 lines) = **4,527 lines added**

#### Source

| File | Lines | Description |
|------|-------|-------------|
| `ribbon.go` | 165 | **Public API surface** — `Ribbon`, `Config`, `New()`, `NewWithConfig()`, `Build()`, `Contains()`, `ErrConstructionFailed`. This is the only file users import. |
| `builder.go` | 448 | **Pipeline orchestrator** — wires hash → bander → solver → filter. Implements seed-retry loop, RocksDB-style dynamic slot computation with empirical lookup tables, config validation/normalisation. |
| `solver.go` | 322 | **Back-substitution** (paper §2) — solves the upper-triangular banded system produced by the bander. Width-specialised paths for w=64 (pure `uint64`) and w=128 (lo/hi split). Includes GF(2) parity helpers using `math/bits.OnesCount64`. |
| `filter.go` | 179 | **Query evaluation** (paper §2–3) — immutable, thread-safe filter struct. Zero-allocation `containsHash()` with bounds-check elimination via 128-byte padding. Also provides `fpRate()` for empirical FPR estimation. |
| `go.mod` | 1 | Module path renamed: `github.com/dhruvil/ribbon` → `github.com/ribnonGo/ribbon`. |

#### Tests & Benchmarks

| File | Lines | What it covers |
|------|-------|----------------|
| `ribbon_test.go` | 691 | 23 public API tests — correctness, FPR validation, all config combos (w×r×fcao), edge cases (empty, single key, rebuild, invalid config panics), scale tests at n=100K. |
| `ribbon_bench_test.go` | 349 | Paper-aligned benchmarks at n=10⁶ and n=10⁸ for Build, Query (positive/negative), and Space across all three widths. |
| `filter_test.go` | 732 | Internal pipeline tests — round-trip (build→query), FPR statistical validation, cross-width consistency, empty/single-slot edge cases. |
| `filter_bench_test.go` | 398 | Internal construction and query benchmarks across all widths. |
| `solver_test.go` | 776 | Solver unit tests — identity/single-equation/full-rank systems, GF(2) parity correctness, width-specialised back-substitution, edge cases. |
| `solver_bench_test.go` | 467 | Solver benchmarks — back-substitution and query throughput at multiple scales. |

---

### Design decisions

#### Minimal public API

Only `ribbon.go` exports symbols. Every other file is internal (`unexported`). The entire user-facing surface is:

- `New()` / `NewWithConfig(Config)` — create a filter
- `Build([]string)` — construct from keys
- `Contains(string)` — query membership
- `Config` — all paper parameters (w, r, firstCoeffAlwaysOne, maxSeeds)
- `ErrConstructionFailed` — sentinel error

#### Dynamic slot computation (ported from RocksDB)

The original fixed formula (`m/n ≈ 1 + 2.3/w + 0.03`) breaks at large *n*. This PR ports RocksDB's `BandingConfigHelper1::GetNumSlots` from `ribbon_config.cc`, which uses empirical lookup tables where overhead grows **logarithmically** with *n*:

```
factor = baseFactor + log2(numSlots) × factorPerPow2
```

Separate config tables for w=128, w=64, and w=32 (extrapolated, since RocksDB doesn't support w=32).

#### Zero-allocation query path

`Contains()` performs zero heap allocations:
- `standardHasher` stored by value (not pointer) for devirtualisation
- Solution vector padded by 128 bytes for bounds-check elimination (`_ = data[127]`)
- Branchless coefficient derivation via pre-computed masks

#### Width-specialised solver

`backSubstitute()` dispatches to:
- **w ≤ 64**: pure `uint64` operations — single `parity64()` call per slot
- **w = 128**: separate lo/hi `uint64` operations — `parity128()` XORs two halves

---

### Benchmark results

**Apple M3 Pro · Go 1.25 · ARM64 · r=7 · firstCoeffAlwaysOne=true**

#### Build (construction)

| *n* | Width | ns/key | bits/key | Overhead |
|-----|-------|--------|----------|----------|
| 10⁶ | w=32 | 56.89 | 10.54 | 31.81% |
| 10⁶ | w=64 | 64.56 | 8.959 | 11.99% |
| 10⁶ | w=128 | 106.3 | 8.380 | 4.749% |
| 10⁸ | w=32 | 355.3 | 11.62 | 45.30% |
| 10⁸ | w=64 | 266.2 | 9.406 | 17.58% |
| 10⁸ | w=128 | 384.7 | 8.585 | 7.314% |

#### Query (lookup)

| Width | Positive (ns/op) | Negative (ns/op) |
|-------|-------------------|-------------------|
| w=32 | 37.25 | 36.85 |
| w=64 | 53.70 | 52.49 |
| w=128 | 88.66 | 84.73 |

#### Space efficiency

| *n* | Width | bits/key | packed bits/key | Overhead |
|-----|-------|----------|-----------------|----------|
| 10⁶ | w=128 | 8.380 | 7.332 | 4.749% |
| 10⁸ | w=128 | 8.585 | 7.512 | 7.314% |

> w=128 at n=10⁶: **8.38 bits/key** vs Bloom's 9.6 bits/key — **12.7% smaller** for the same FPR.

---

### Testing

All **118 top-level test functions** (348 subtests) pass:

```
ok  github.com/ribnonGo/ribbon  2.9s
```

Coverage areas:
- **Zero false negatives** — every inserted key round-trips through build→query
- **FPR validation** — empirical FPR at n=100K verified against 2<sup>−r</sup> theoretical bound (within 20% tolerance)
- **All 12 configurations** — w ∈ {32, 64, 128} × r ∈ {1, 4, 7, 8} × firstCoeffAlwaysOne ∈ {true, false}
- **Edge cases** — empty input, single key, nil filter, rebuild semantics, duplicate key detection, invalid config panics
- **Cross-validation** — optimised paths verified against reference (`slow*`) implementations slot-by-slot

---

### How to verify

```bash
# Run all tests
go test -v -count=1 ./...

# Run only public API tests
go test -v -run='^TestRibbon' -count=1

# Run paper-aligned benchmarks
go test -run=^$ -bench='BenchmarkRibbon' -benchtime=3s -count=1
```

---

### Remaining work (future PRs)

- [ ] Serialization / deserialization (`MarshalBinary` / `UnmarshalBinary`)
- [ ] `[]byte` key support alongside `[]string`
- [ ] Parallel construction for large key sets
- [ ] README update with final benchmarks and complete documentation
