### PR TITLE
fix: delegate Ribbon.Contains to filter.contains instead of calling xxh3 directly

### DIFF
--- a/ribbon.go
+++ b/ribbon.go
@@ -2,8 +2,6 @@ package ribbonGo
 
 import (
 	"errors"
-
-	"github.com/zeebo/xxh3"
 )
 
 // =============================================================================
@@ -201,5 +199,5 @@ func (r *Ribbon) Contains(key string) bool {
 	if r.f == nil {
 		return false
 	}
-	return r.f.containsHash(xxh3.HashString(key))
+	return r.f.contains(key)
 }


### PR DESCRIPTION
## Summary

`Ribbon.Contains()` was directly calling `xxh3.HashString(key)` and passing the result to `f.containsHash()`, bypassing the hasher abstraction that `filter.contains()` already encapsulates.

This couples the public API to a specific hash implementation. If `keyHashString()` is ever changed (e.g., adding a salt, switching hash functions, or preprocessing), `Ribbon.Contains` would silently diverge from `Build`, producing incorrect query results.

## Changes

- **`ribbon.go`**: Delegate `Ribbon.Contains(key)` to `f.contains(key)` instead of `f.containsHash(xxh3.HashString(key))`.
- Remove the now-unused `github.com/zeebo/xxh3` import from `ribbon.go`.

## Why

`filter.contains()` already correctly hashes the key through the hasher abstraction (`hasher.keyHashString`). The public API should use this existing method rather than reimplementing Phase 1 hashing directly. No performance impact — `keyHashString` calls the same `xxh3.HashString` today, and the method is inlineable.

Fixes #37