### PR TITLE
Switch query storage to Interleaved Column-Major Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ Construction throughput and space efficiency at scale.
 
 | *n* | Width | ns/key | bits/key | Overhead |
 |-----|-------|--------|----------|----------|
-| 10⁶ | w=32 | 56.89 | 10.54 | 31.81% |
-| 10⁶ | w=64 | 64.56 | 8.959 | 11.99% |
-| 10⁶ | w=128 | 106.3 | 8.380 | 4.749% |
-| 10⁸ | w=32 | 355.3 | 11.62 | 45.30% |
-| 10⁸ | w=64 | 266.2 | 9.406 | 17.58% |
-| 10⁸ | w=128 | 384.7 | 8.585 | 7.314% |
+| 10⁶ | w=32 | 56.89 | 9.227 | 31.81% |
+| 10⁶ | w=64 | 64.56 | 7.840 | 11.99% |
+| 10⁶ | w=128 | 106.3 | 7.334 | 4.749% |
+| 10⁸ | w=32 | 355.3 | 10.17 | 45.30% |
+| 10⁸ | w=64 | 266.2 | 8.231 | 17.58% |
+| 10⁸ | w=128 | 384.7 | 7.512 | 7.314% |
 
-> At *n* = 10⁶, `w=128` achieves **8.38 bits/key** — only 4.7% above the information-theoretic minimum (7 bits for r=7). At *n* = 10⁸, it remains under 8.6 bits/key with just 7.3% overhead.
+> `bits/key` is the **actual ICML physical storage** (paper §5.2): the *r* result columns packed at *r* bits per slot, i.e. `r × numSlots / n`, not one byte per slot. At *n* = 10⁶, `w=128` achieves **7.33 bits/key** — only 4.7% above the information-theoretic minimum (7 bits for r=7). At *n* = 10⁸, it remains under 7.6 bits/key with just 7.3% overhead.
 
 ### Query Performance
 
@@ -181,18 +181,20 @@ Lookup latency per key (*n* = 10⁶), measured on an **x86 Xeon Platinum** host 
 
 ### Space Efficiency
 
-Bits per key at both scales, with packed (information-theoretic) comparison.
+Actual ICML physical storage (paper §5.2) at both scales. `bits/key` is the *r*
+result columns packed at *r* bits per slot (`r × numSlots / n`); the
+information-theoretic minimum for r=7 is 7 bits/key.
 
-| *n* | Width | bits/key | packed bits/key | Overhead |
-|-----|-------|----------|-----------------|----------|
-| 10⁶ | w=32 | 10.54 | 9.227 | 31.81% |
-| 10⁶ | w=64 | 8.959 | 7.839 | 11.99% |
-| 10⁶ | w=128 | 8.380 | 7.332 | 4.749% |
-| 10⁸ | w=32 | 11.62 | 10.17 | 45.30% |
-| 10⁸ | w=64 | 9.406 | 8.231 | 17.58% |
-| 10⁸ | w=128 | 8.585 | 7.512 | 7.314% |
+| *n* | Width | bits/key | Overhead |
+|-----|-------|----------|----------|
+| 10⁶ | w=32 | 9.227 | 31.81% |
+| 10⁶ | w=64 | 7.840 | 11.99% |
+| 10⁶ | w=128 | 7.334 | 4.749% |
+| 10⁸ | w=32 | 10.17 | 45.30% |
+| 10⁸ | w=64 | 8.231 | 17.58% |
+| 10⁸ | w=128 | 7.512 | 7.314% |
 
-> **w=128** at *n* = 10⁶ uses only **8.38 bits/key** — compare with Bloom filters at **9.6 bits/key** for the same FPR. That's a **12.7% space saving** over Bloom.
+> **w=128** at *n* = 10⁶ uses only **7.33 bits/key** — compare with Bloom filters at **9.6 bits/key** for the same FPR. That's a **23.6% space saving** over Bloom.
 
 ### Run Benchmarks Yourself
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ The public API is intentionally minimal — a single type with four functions.
 
 ## Benchmarks
 
-**Apple M3 Pro · Go 1.25 · ARM64 · r = 7 result bits · firstCoeffAlwaysOne = true**
+**Query numbers: x86 Xeon Platinum · Go 1.25 · amd64 · r = 7 result bits · firstCoeffAlwaysOne = true**
 
 All benchmarks follow the methodology of Dillinger & Walzer (2021), testing at both *n* = 10⁶ and *n* = 10⁸ keys.
+
+> The *Build* and *Space* tables below were measured on an Apple M3 Pro (ARM64); the *Query Performance* table was re-measured on an x86 Xeon Platinum host after the ICML migration. Space/correctness figures (bits/key, FPR) are CPU-independent; absolute ns/op are not comparable across the two hosts.
 
 ### Build Performance
 
@@ -165,15 +167,17 @@ Construction throughput and space efficiency at scale.
 
 ### Query Performance
 
-Lookup latency per key (*n* = 10⁶).
+Lookup latency per key (*n* = 10⁶), measured on an **x86 Xeon Platinum** host (see the note under *Benchmarks*). Queries use the [Interleaved Column-Major Layout](#memory-layout-interleaved-column-major-icml) (paper §5.2).
 
 | Width | Positive (ns/op) | Negative (ns/op) |
 |-------|-------------------|-------------------|
-| w=32 | 37.25 | 36.85 |
-| w=64 | 53.70 | 52.49 |
-| w=128 | 88.66 | 84.73 |
+| w=32 | 32.3 | 26.9 |
+| w=64 | 31.5 | 26.3 |
+| w=128 | 43.2 | 31.7 |
 
-> Query time scales linearly with ribbon width, as expected — the inner loop performs a dot product over *w* bits. Positive and negative queries have nearly identical cost.
+> With ICML the query decodes the *r* result columns one at a time (each an XOR-fold + POPCNT parity) rather than XOR-ing ~*w*/2 solution bytes, so cost is roughly flat in *w* for w ≤ 64 and only rises at w = 128 (two 64-bit halves per column). Negative queries **short-circuit** on the first mismatched result column (paper §5.2), so they are consistently faster than positive queries — the opposite of the old row-major layout, where the full dot product was always computed.
+>
+> Isolating just the filter query (pre-hashed `ContainsHash`, no XXH3) makes the layout change stark versus the previous row-major layout on the same host: w=64 positive drops from ~42 ns to ~19 ns and w=128 from ~74 ns to ~35 ns; negatives fall to ~8–11 ns across all widths.
 
 ### Space Efficiency
 
@@ -221,14 +225,17 @@ Key → [Hash] → [Bander] → [Solver] → [Filter/Query]
 | **uint128** | `uint128.go` | 128-bit integer type for coefficient rows when w=128. |
 | **Hash** | `hash.go` | Two-phase pipeline: hash each key once with XXH3, then cheaply remix per seed to derive `(start, coeffRow, result)` triples. |
 | **Bander** | `bander.go` | On-the-fly Gaussian elimination over GF(2). Converts hashed equations into an upper-triangular banded matrix. Hottest code path during construction. |
-| **Solver** | `solver.go` | Back-substitution: solves the upper-triangular system to produce the compact solution vector encoding the filter. |
-| **Filter** | `filter.go` | Query evaluation: one hash, one dot product over GF(2). Also provides false-positive rate estimation. |
+| **Solver** | `solver.go` | Back-substitution: solves the upper-triangular system, writing the solution directly into the [Interleaved Column-Major Layout](#memory-layout-interleaved-column-major-icml) (paper §5.2). The row-major solution is retained only as a cross-validation oracle. |
+| **Filter** | `filter.go` | Query evaluation: one hash, then a per-result-column GF(2) dot product over the ICML words, short-circuiting on the first mismatch. Also provides false-positive rate estimation. |
 | **Builder** | `builder.go` | Orchestrates the full pipeline: hashing → banding → solving → filter construction. Includes RocksDB-style dynamic slot computation. |
 | **Public API** | `ribbon.go` | Sole public surface: `Ribbon`, `Config`, `New()`, `NewWithConfig()`, `Build()`, `Contains()`. |
 
 ### Key Optimisations
 
-**SoA layout** — Coefficient data is stored in parallel arrays (`coeffLo []uint64`, `coeffHi []uint64`, `result []uint8`) instead of an array of structs. For w≤64, `coeffHi` is `nil` — zero memory, zero operations. This doubles the number of coefficients per cache line compared to AoS layout.
+<a name="memory-layout-interleaved-column-major-icml"></a>
+**Memory layout (Interleaved Column-Major, ICML)** — The solved solution *Z* is stored in the Interleaved Column-Major Layout from paper §5.2 (RocksDB's `InterleavedSolutionStorage`), *not* one byte per slot. Memory is divided into *w*-bit **words** grouped into **blocks** of *r* words; block *b* is the column-major transpose of solution rows `[b·w, b·w + w)`, so `bit k of word(b, j) = Z[b·w + k].bit_j`. A query at start *s* reads column *j* from the two words straddling the block boundary at *s* (blocks `s/w` and `s/w+1`), shifts by `s % w` to reconstruct the *w*-bit column slice, and takes `parity(slice & coeffRow)` for each of the *r* result columns — comparing to the expected fingerprint and short-circuiting on the first mismatch. Because `numSlots` is rounded up to a multiple of *w* and one trailing zero block is allocated, a single width-specific bounds-check-elimination proof covers the whole two-block read with no per-column bounds checks. Physical storage is width-specialised: `[]uint64` for w ∈ {64, 128} and `[]uint32` for w = 32 (the unpacked encoding won a benchmark against a packed two-lanes-per-`uint64` variant).
+
+**SoA layout (construction)** — During banding, coefficient data is stored in parallel arrays (`coeffLo []uint64`, `coeffHi []uint64`, `result []uint8`) instead of an array of structs. For w≤64, `coeffHi` is `nil` — zero memory, zero operations. This doubles the number of coefficients per cache line compared to AoS layout.
 
 **Width specialisation** — `add()` dispatches to `addW64()` (pure `uint64`, ~10 ARM64 instructions per elimination step) or `addW128()` (separate lo/hi `uint64` ops). The generic `uint128.rsh()` branch dispatch is avoided entirely.
 

--- a/builder.go
+++ b/builder.go
@@ -362,9 +362,16 @@ func computeNumSlots(numKeys int, coeffBits uint32) uint32 {
 	// numSlots MUST be a multiple of the ribbon width w. Round up. The
 	// minSlots floor (coeffBits*2) is already a multiple of w, so this only
 	// grows numSlots when the interpolated value is not w-aligned.
-	numSlots = ((numSlots + coeffBits - 1) / coeffBits) * coeffBits
+	numSlots = roundUpToMultiple(numSlots, coeffBits)
 
 	return numSlots
+}
+
+// roundUpToMultiple rounds n up to the nearest multiple of w (w > 0).
+// Used to enforce the ICML invariant that numSlots is a multiple of the
+// ribbon width w.
+func roundUpToMultiple(n, w uint32) uint32 {
+	return ((n + w - 1) / w) * w
 }
 
 // computeNumStarts derives the number of valid start positions from the
@@ -401,7 +408,7 @@ func buildCoreWithOverride(hashes []uint64, cfg Config, overheadRatio float64) (
 	// ICML invariant (paper §5.2): numSlots must be a multiple of the ribbon
 	// width w. Round numSlots up to a multiple of w and recompute numStarts
 	// so the hasher and bander agree with the rounded slot count.
-	numSlots = ((numSlots + cfg.CoeffBits - 1) / cfg.CoeffBits) * cfg.CoeffBits
+	numSlots = roundUpToMultiple(numSlots, cfg.CoeffBits)
 	numStarts = numSlots - cfg.CoeffBits + 1
 
 	h := newStandardHasher(cfg.CoeffBits, numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
@@ -409,7 +416,7 @@ func buildCoreWithOverride(hashes []uint64, cfg Config, overheadRatio float64) (
 
 	for seed := uint32(0); seed < cfg.MaxSeeds; seed++ {
 		h.setOrdinalSeed(seed)
-		
+
 		bd.reset()
 		if bd.addRange(hashes, h) {
 			sol := backSubstituteICML(bd, cfg.CoeffBits, cfg.ResultBits)

--- a/builder.go
+++ b/builder.go
@@ -139,8 +139,8 @@ func buildCore(hashes []uint64, cfg Config) (*filter, error) {
 
 		// Attempt banding: on-the-fly Gaussian elimination over GF(2).
 		if bd.addRange(hashes, h) {
-			// Success! Back-substitute to compute the solution vector S.
-			sol := backSubstitute(bd, cfg.ResultBits)
+			// Success! Back-substitute into the ICML query representation.
+			sol := backSubstituteICML(bd, cfg.CoeffBits, cfg.ResultBits)
 			return newFilterFromSolution(sol, h, seed, numSlots), nil
 		}
 		// Banding failed (linear dependence). Try next seed.
@@ -412,37 +412,29 @@ func buildCoreWithOverride(hashes []uint64, cfg Config, overheadRatio float64) (
 		
 		bd.reset()
 		if bd.addRange(hashes, h) {
-			sol := backSubstitute(bd, cfg.ResultBits)
+			sol := backSubstituteICML(bd, cfg.CoeffBits, cfg.ResultBits)
 			return newFilterFromSolution(sol, h, seed, numSlots), nil
 		}
 	}
 	return nil, ErrConstructionFailed
 }
 
-// newFilterFromSolution packages a solution into a filter, padding the
-// data array for bounds-check elimination in the contains hot path.
+// newFilterFromSolution packages an ICML solution into a filter for querying.
 //
-// The solution data from backSubstitute has length numSlots + w (where w
-// is the solver's detected width — which may be 64 for w=32, see note
-// in backSubstitute). We re-allocate with numSlots + 128 bytes of
-// capacity so that contains can use a single `_ = data[127]` BCE proof
-// for all ribbon widths:
-//
-//	For w=32:  max start = numSlots-32,  data[start:] has len ≥ 160  → data[127] ✓
-//	For w=64:  max start = numSlots-64,  data[start:] has len ≥ 192  → data[127] ✓
-//	For w=128: max start = numSlots-128, data[start:] has len ≥ 256  → data[127] ✓
-//
-// The extra padding bytes are always zero, matching the semantics of
-// empty (unoccupied) solution slots.
-func newFilterFromSolution(sol *solution, h *standardHasher, seed uint32, numSlots uint32) *filter {
-	paddedLen := int(numSlots) + 128
-	data := make([]uint8, paddedLen)
-	copy(data, sol.data)
-
+// The icmlSolution already carries the width-specific physical store sized for
+// numBlocks data blocks plus one trailing zero block (see newICMLSolution). The
+// trailing zero block lets containsHash read word(blockIdx+1, j) at any valid
+// start without a boundary branch while a single width-specific BCE proof keeps
+// the per-column reads bounds-check-free. We copy the backing slice(s), enc,
+// and numBlocks straight across.
+func newFilterFromSolution(sol *icmlSolution, h *standardHasher, seed uint32, numSlots uint32) *filter {
 	return &filter{
-		data:     data,
-		hasher:   *h, // copy by value for cache locality
-		seed:     seed,
-		numSlots: numSlots,
+		data64:    sol.data64,
+		data32:    sol.data32,
+		numBlocks: sol.numBlocks,
+		enc:       sol.enc,
+		hasher:    *h, // copy by value for cache locality
+		seed:      seed,
+		numSlots:  numSlots,
 	}
 }

--- a/builder.go
+++ b/builder.go
@@ -357,6 +357,13 @@ func computeNumSlots(numKeys int, coeffBits uint32) uint32 {
 		numSlots = minSlots
 	}
 
+	// ICML invariant (paper §5.2): the Interleaved Column-Major Layout groups
+	// slots into blocks of exactly w rows (numBlocks = numSlots / w), so
+	// numSlots MUST be a multiple of the ribbon width w. Round up. The
+	// minSlots floor (coeffBits*2) is already a multiple of w, so this only
+	// grows numSlots when the interpolated value is not w-aligned.
+	numSlots = ((numSlots + coeffBits - 1) / coeffBits) * coeffBits
+
 	return numSlots
 }
 
@@ -390,6 +397,12 @@ func buildCoreWithOverride(hashes []uint64, cfg Config, overheadRatio float64) (
 	numKeys := len(hashes)
 	numStarts := computeNumStarts(numKeys, overheadRatio)
 	numSlots := numStarts + cfg.CoeffBits - 1
+
+	// ICML invariant (paper §5.2): numSlots must be a multiple of the ribbon
+	// width w. Round numSlots up to a multiple of w and recompute numStarts
+	// so the hasher and bander agree with the rounded slot count.
+	numSlots = ((numSlots + cfg.CoeffBits - 1) / cfg.CoeffBits) * cfg.CoeffBits
+	numStarts = numSlots - cfg.CoeffBits + 1
 
 	h := newStandardHasher(cfg.CoeffBits, numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
 	bd := newStandardBander(numSlots, cfg.CoeffBits, cfg.FirstCoeffAlwaysOne)

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,57 @@
+package ribbonGo
+
+import (
+	"fmt"
+	"testing"
+)
+
+// =============================================================================
+// ICML numSlots multiple-of-w invariant (Task 1)
+//
+// The Interleaved Column-Major Layout (paper §5.2) groups slots into blocks
+// of exactly w rows, so numSlots must be a multiple of the ribbon width w on
+// both build paths (computeNumSlots and buildCoreWithOverride).
+// =============================================================================
+
+func TestComputeNumSlots_MultipleOfW(t *testing.T) {
+	for _, w := range []uint32{32, 64, 128} {
+		for _, numKeys := range []int{1, 100, 1000, 100000} {
+			name := fmt.Sprintf("w=%d/n=%d", w, numKeys)
+			t.Run(name, func(t *testing.T) {
+				numSlots := computeNumSlots(numKeys, w)
+				if numSlots%w != 0 {
+					t.Errorf("numSlots=%d is not a multiple of w=%d", numSlots, w)
+				}
+				minSlots := w * 2
+				if numSlots < minSlots {
+					t.Errorf("numSlots=%d < minSlots=%d", numSlots, minSlots)
+				}
+			})
+		}
+	}
+}
+
+func TestBuildCoreOverride_MultipleOfW(t *testing.T) {
+	// Ratios like 1.2 previously produced non-multiple-of-w numSlots. Assert
+	// both the ICML slot invariant and the numStarts consistency after rounding.
+	const numKeys = 1000
+	for _, cfg := range allConfigs() {
+		for _, ratio := range []float64{1.2, 1.05, 1.333} {
+			name := fmt.Sprintf("%s/ratio=%.3f", configName(cfg), ratio)
+			t.Run(name, func(t *testing.T) {
+				hashes := generateHashes("override_mow", numKeys)
+				f, err := buildCoreWithOverride(hashes, normalizeConfig(cfg), ratio)
+				if err != nil {
+					t.Fatalf("buildCoreWithOverride failed: %v", err)
+				}
+				if f.numSlots%cfg.CoeffBits != 0 {
+					t.Errorf("numSlots=%d not a multiple of w=%d", f.numSlots, cfg.CoeffBits)
+				}
+				if f.hasher.numStarts != f.numSlots-cfg.CoeffBits+1 {
+					t.Errorf("numStarts=%d, want %d (numSlots - w + 1)",
+						f.hasher.numStarts, f.numSlots-cfg.CoeffBits+1)
+				}
+			})
+		}
+	}
+}

--- a/filter.go
+++ b/filter.go
@@ -101,18 +101,20 @@ type filter struct {
 // and check whether c(x) · S[s(x)..s(x)+w-1] = r(x) over GF(2)."
 //
 // Performance: this method is the most frequently called code in the
-// entire library. It is designed for:
+// entire library. The query decodes the ICML solution (paper §5.2) and is
+// designed for:
 //   - Zero heap allocations: hashResult is a value type (stack-allocated),
 //     and derive() is inlineable (cost 67 < budget 80).
-//   - Minimal branching: the only branch is the numStarts==0 guard
-//     (always-false for non-empty filters, perfectly predicted).
-//   - Bounds-check elimination: a single `_ = data[127]` proof at the
-//     top of containsHash eliminates all per-iteration bounds checks.
-//   - Skip-zero iteration: the dot-product loop iterates only over set
-//     bits using TZCNT + clear-lowest-bit, halving iteration count vs
-//     a naive 0..w loop (~w/2 iterations for random coefficient rows).
+//   - Minimal branching: the numStarts==0 guard and, in containsHash, one
+//     branch on the ICML encoding (w=32 vs w≤64 vs w=128).
+//   - Bounds-check elimination: a single width-specific `_ = store[maxIdx]`
+//     proof at the top of containsHash eliminates all per-column bounds
+//     checks (the trailing zero block keeps the two-block read in bounds).
+//   - Column short-circuit: containsHash compares result columns one at a
+//     time and returns false on the first mismatch, so non-members exit
+//     early (D3).
 //
-// [RocksDB: SimpleFilterQuery in ribbon_alg.h]
+// [RocksDB: InterleavedFilterQuery in ribbon_alg.h]
 func (f *filter) contains(key string) bool {
 	if f.hasher.numStarts == 0 {
 		return false

--- a/filter.go
+++ b/filter.go
@@ -19,13 +19,27 @@ import "math/bits"
 // the coefficient row against the solution window, and compares the
 // computed result to the expected fingerprint.
 //
-// Memory layout:
+// Memory layout (ICML — Interleaved Column-Major Layout, paper §5.2):
 //
-// The solution vector is stored as one uint8 per slot (row-major), padded
-// to numSlots + 128 bytes. The extra 128 bytes ensure that containsHash
-// can use a single bounds-check elimination proof (`_ = data[127]`) for
-// all ribbon widths (w = 32, 64, 128), avoiding per-iteration bounds
-// checks in the dot-product loop.
+// The solution is stored in RocksDB's InterleavedSolutionStorage format:
+// memory is divided into w-bit logical words, grouped into blocks of r
+// words, where block b is the column-major transpose of solution rows
+// [b·w, b·w + w). A query at start s reads column j from the two logical
+// words that straddle the block boundary at s (block s/w and s/w+1),
+// combines them with a shift by s%w, and takes the GF(2) dot product with
+// the coefficient row.
+//
+// One trailing zero block is allocated beyond the numBlocks data blocks so
+// the query may read word(blockIdx+1, j) unconditionally (no branch on the
+// last block) while remaining in bounds under a single width-specific BCE
+// proof at the top of containsHash. This replaces the old row-major
+// "+128-byte" padding: bounds are proved per width from blockIdx and r.
+//
+// Physical storage is width-specific and selected by enc:
+//   - w=64:  data64, logical word L → data64[L].
+//   - w=128: data64, L → (data64[2L+1] : data64[2L]).
+//   - w=32:  data64 with two 32-bit lanes per uint64 (packed encoding).
+// Only one backing slice is populated per encoding.
 //
 // The standardHasher is stored by value (not pointer) so that its ~96
 // bytes of pre-computed masks sit adjacent to the slice header in memory,
@@ -35,12 +49,26 @@ import "math/bits"
 // containsHash may be called concurrently from multiple goroutines
 // without synchronisation.
 //
-// [RocksDB: InMemSimpleSolution + SimpleFilterQuery in ribbon_impl.h / ribbon_alg.h]
+// [RocksDB: InterleavedSolutionStorage + InterleavedFilterQuery in ribbon_impl.h / ribbon_alg.h]
 type filter struct {
-	// data holds the solution vector: one r-bit result row (uint8) per
-	// slot, padded to numSlots + 128 bytes for bounds-check elimination.
-	// Padding bytes are zero, matching empty (unoccupied) solution slots.
-	data []uint8
+	// data64 holds the ICML solution words (see icmlSolution). It backs the
+	// w=64, w=128, and packed-w=32 encodings; only one backing slice is used
+	// per encoding.
+	data64 []uint64
+
+	// data32 backs the unpacked w=32 encoding only (nil otherwise). Retained
+	// so both w=32 encodings are queryable behind the accessor until Task 4
+	// settles the packing decision.
+	data32 []uint32
+
+	// numBlocks is numSlots / w — the number of ICML data blocks (excluding
+	// the trailing zero block).
+	numBlocks uint32
+
+	// enc selects the physical ICML encoding for this filter's width, copied
+	// from the icmlSolution so the query path maps logical→physical without
+	// re-deriving it from the width.
+	enc icmlEncoding
 
 	// hasher is the concrete standardHasher configured with the successful
 	// seed and all per-width pre-computed masks (coeffLoMask, coeffHiMask,
@@ -95,70 +123,168 @@ func (f *filter) contains(key string) bool {
 	return f.containsHash(h)
 }
 
-// containsHash is the inlined query core. It performs the full Phase 2
-// derive + GF(2) dot product in one tight sequence.
+// containsHash is the inlined ICML query core. It performs the full Phase 2
+// derive + per-column GF(2) dot product with short-circuiting.
 //
-// Algorithm:
+// Algorithm (paper §5.2, InterleavedFilterQuery):
 //
-//  1. derive(h) → (start, coeffRow, expectedResult)
-//     derive() is inlineable (cost 67) and computes:
-//     - rehash: (h ^ rawSeed) * kRehashFactor
-//     - start:  fastRange64(rehashed, numStarts)   [high bits]
-//     - coeff:  multiply → mask/xor/or             [branchless]
-//     - result: multiply → bswap → mask            [byte-swapped]
+//  1. derive(h) → (start, coeffRow, expectedResult).
 //
-//  2. Dot product: iterate over set bits in coeffRow, XOR the
-//     corresponding solution bytes into a running result.
-//     Uses TrailingZeros64 (TZCNT/BSF) + clear-lowest-bit (BLSR)
-//     to visit only the ~w/2 set bits in a random coefficient row.
+//  2. blockIdx = start/w, offset = start%w. Rows [start, start+w) span
+//     ICML block blockIdx (its upper w-offset rows) and block blockIdx+1
+//     (its lower offset rows). For each result column j, read the two
+//     logical words word(blockIdx, j) and word(blockIdx+1, j), combine
+//     them with a shift by offset to reconstruct the w-bit column slice,
+//     then bit_j = parity(slice & coeffRow).
 //
-//  3. Compare: return (computed == expected).
+//  3. Short-circuit (D3): compare bit_j to (expectedResult >> j) & 1 and
+//     return false immediately on the first mismatch. A non-member fails
+//     column 0 with probability 1/2, so negatives return ~2× faster on
+//     average than the full r-column scan. Returns true after all r
+//     columns match. (icmlSolution.icmlQuery is the non-short-circuit
+//     oracle counterpart.)
 //
 // Bounds-check elimination (BCE):
 //
-// A single `_ = data[127]` proof guarantees all per-iteration accesses
-// are in-bounds. The filter's data is padded to numSlots + 128 bytes,
-// and the maximum start is numStarts - 1 = numSlots - w, so
-// data[start:] has length >= w + 128 >= 160 for all w in {32, 64, 128}.
-//
-// The `& 63` masks on TrailingZeros64 results provide a compile-time
-// proof that lo-loop indices are in [0, 63] and hi-loop indices are
-// in [64, 127], both <= 127, eliminating bounds checks entirely.
+// A single width-specific `_ = store[maxIdx]` proof at the top guarantees
+// all per-column reads are in-bounds. The two-block read touches at most
+// logical word (blockIdx+2)·r - 1; the trailing zero block ensures this is
+// always allocated, so maxIdx is derived from blockIdx, r, and the
+// width-specific logical→physical mapping — no per-column bounds checks and
+// no branch on blockIdx == numBlocks-1.
 //
 // Returns false for empty filters (numStarts == 0).
 //
-// [RocksDB: SimpleQueryHelper in ribbon_alg.h]
+// [RocksDB: InterleavedFilterQuery in ribbon_alg.h]
 func (f *filter) containsHash(h uint64) bool {
 	if f.hasher.numStarts == 0 {
 		return false
 	}
 
 	hr := f.hasher.derive(h)
+	w := f.hasher.coeffBits
+	r := uint32(f.hasher.resultBits)
 
-	// Slice the solution window starting at the key's start position.
-	// The BCE proof ensures data[0..127] are all in-bounds.
-	data := f.data[hr.start:]
-	_ = data[127] // BCE proof: all subsequent accesses are within [0, 127].
+	blockIdx := hr.start / w
+	offset := hr.start % w
 
-	// GF(2) dot product: XOR solution bytes at each set coefficient bit.
-	var result uint8
+	// Logical word index of word(blockIdx+1, r-1) — the highest logical word
+	// the two-block read can touch this query.
+	maxL := (blockIdx+2)*r - 1
 
-	// Process the lower 64 bits of the coefficient row (positions 0..63).
-	lo := hr.coeffRow.lo
-	for lo != 0 {
-		result ^= data[bits.TrailingZeros64(lo)&63]
-		lo &= lo - 1 // clear lowest set bit (BLSR)
+	if w == 128 {
+		return f.containsHash128(hr, blockIdx, offset, r, maxL)
 	}
+	return f.containsHash64(hr, w, blockIdx, offset, r, maxL)
+}
 
-	// Process the upper 64 bits (positions 64..127).
-	// For w <= 64, coeffRow.hi is always 0, making this a zero-iteration loop.
-	hi := hr.coeffRow.hi
-	for hi != 0 {
-		result ^= data[64+bits.TrailingZeros64(hi)&63]
-		hi &= hi - 1
+// containsHash64 is the ICML short-circuit query for ribbon width w ≤ 64.
+func (f *filter) containsHash64(hr hashResult, w, blockIdx, offset, r, maxL uint32) bool {
+	c := hr.coeffRow.lo
+	base0 := blockIdx * r
+	base1 := (blockIdx + 1) * r
+
+	switch f.enc {
+	case encW32Unpacked:
+		data := f.data32
+		_ = data[maxL] // BCE proof: all reads below are in [0, maxL].
+		var mask uint64
+		if w < 64 {
+			mask = (uint64(1) << w) - 1
+		} else {
+			mask = ^uint64(0)
+		}
+		for j := uint32(0); j < r; j++ {
+			lo0 := uint64(data[base0+j])
+			var slice uint64
+			if offset == 0 {
+				slice = lo0
+			} else {
+				lo1 := uint64(data[base1+j])
+				slice = ((lo0 >> offset) | (lo1 << (w - offset))) & mask
+			}
+			bit := bits.OnesCount64(slice&c) & 1
+			if bit != int((hr.result>>j)&1) {
+				return false
+			}
+		}
+		return true
+
+	case encW32Packed:
+		data := f.data64
+		_ = data[maxL>>1] // BCE proof: highest physical uint64 index.
+		for j := uint32(0); j < r; j++ {
+			l0 := base0 + j
+			lo0 := (data[l0>>1] >> ((l0 & 1) * 32)) & 0xffffffff
+			var slice uint64
+			if offset == 0 {
+				slice = lo0
+			} else {
+				l1 := base1 + j
+				lo1 := (data[l1>>1] >> ((l1 & 1) * 32)) & 0xffffffff
+				slice = ((lo0 >> offset) | (lo1 << (w - offset))) & ((uint64(1) << w) - 1)
+			}
+			bit := bits.OnesCount64(slice&c) & 1
+			if bit != int((hr.result>>j)&1) {
+				return false
+			}
+		}
+		return true
+
+	default: // encW64
+		data := f.data64
+		_ = data[maxL] // BCE proof: all reads below are in [0, maxL].
+		for j := uint32(0); j < r; j++ {
+			lo0 := data[base0+j]
+			var slice uint64
+			if offset == 0 {
+				slice = lo0
+			} else {
+				lo1 := data[base1+j]
+				slice = (lo0 >> offset) | (lo1 << (w - offset))
+			}
+			bit := bits.OnesCount64(slice&c) & 1
+			if bit != int((hr.result>>j)&1) {
+				return false
+			}
+		}
+		return true
 	}
+}
 
-	return result == hr.result
+// containsHash128 is the ICML short-circuit query for ribbon width w = 128.
+func (f *filter) containsHash128(hr hashResult, blockIdx, offset, r, maxL uint32) bool {
+	data := f.data64
+	_ = data[2*maxL+1] // BCE proof: highest physical (hi) index.
+
+	cLo := hr.coeffRow.lo
+	cHi := hr.coeffRow.hi
+	base0 := blockIdx * r
+	base1 := (blockIdx + 1) * r
+
+	for j := uint32(0); j < r; j++ {
+		l0 := base0 + j
+		lo0 := data[2*l0]
+		hi0 := data[2*l0+1]
+
+		var sLo, sHi uint64
+		if offset == 0 {
+			sLo, sHi = lo0, hi0
+		} else {
+			l1 := base1 + j
+			lo1 := data[2*l1]
+			hi1 := data[2*l1+1]
+			w0 := uint128{hi: hi0, lo: lo0}.rsh(uint(offset))
+			w1 := uint128{hi: hi1, lo: lo1}.lsh(uint(128 - offset))
+			s := w0.or(w1)
+			sLo, sHi = s.lo, s.hi
+		}
+		bit := bits.OnesCount64((sLo&cLo)^(sHi&cHi)) & 1
+		if bit != int((hr.result>>j)&1) {
+			return false
+		}
+	}
+	return true
 }
 
 // =============================================================================

--- a/filter.go
+++ b/filter.go
@@ -40,6 +40,7 @@ import "math/bits"
 //   - w=128: data64, L → (data64[2L+1] : data64[2L]).
 //   - w=32:  data32 (unpacked []uint32), L → data32[L]. Chosen over a
 //     packed two-lanes-per-uint64 encoding by the Task 4 benchmark.
+//
 // Only one backing slice is populated per encoding.
 //
 // The standardHasher is stored by value (not pointer) so that its ~96
@@ -144,14 +145,11 @@ func (f *filter) contains(key string) bool {
 //     columns match. (icmlSolution.icmlQuery is the non-short-circuit
 //     oracle counterpart.)
 //
-// Bounds-check elimination (BCE):
-//
-// A single width-specific `_ = store[maxIdx]` proof at the top guarantees
-// all per-column reads are in-bounds. The two-block read touches at most
-// logical word (blockIdx+2)·r - 1; the trailing zero block ensures this is
-// always allocated, so maxIdx is derived from blockIdx, r, and the
-// width-specific logical→physical mapping — no per-column bounds checks and
-// no branch on blockIdx == numBlocks-1.
+// Bounds-check elimination (BCE): maxL = (blockIdx+2)·r - 1 is the highest
+// logical word the two-block read can touch (the trailing zero block keeps it
+// in bounds). Each width branch hoists a single `_ = data[...]` proof from it
+// (see containsHash64 / containsHash128) so the per-column reads carry no
+// bounds checks and there is no branch on blockIdx == numBlocks-1.
 //
 // Returns false for empty filters (numStarts == 0).
 //
@@ -187,7 +185,8 @@ func (f *filter) containsHash64(hr hashResult, w, blockIdx, offset, r, maxL uint
 	if f.enc == encW32 {
 		data := f.data32
 		_ = data[maxL] // BCE proof: all reads below are in [0, maxL].
-		mask := (uint64(1) << w) - 1 // w == 32 here
+		// This branch is always w == 32, so the mask is a compile-time constant.
+		const mask = uint64(1)<<32 - 1
 		for j := uint32(0); j < r; j++ {
 			lo0 := uint64(data[base0+j])
 			var slice uint64

--- a/filter.go
+++ b/filter.go
@@ -38,7 +38,8 @@ import "math/bits"
 // Physical storage is width-specific and selected by enc:
 //   - w=64:  data64, logical word L → data64[L].
 //   - w=128: data64, L → (data64[2L+1] : data64[2L]).
-//   - w=32:  data64 with two 32-bit lanes per uint64 (packed encoding).
+//   - w=32:  data32 (unpacked []uint32), L → data32[L]. Chosen over a
+//     packed two-lanes-per-uint64 encoding by the Task 4 benchmark.
 // Only one backing slice is populated per encoding.
 //
 // The standardHasher is stored by value (not pointer) so that its ~96
@@ -51,14 +52,11 @@ import "math/bits"
 //
 // [RocksDB: InterleavedSolutionStorage + InterleavedFilterQuery in ribbon_impl.h / ribbon_alg.h]
 type filter struct {
-	// data64 holds the ICML solution words (see icmlSolution). It backs the
-	// w=64, w=128, and packed-w=32 encodings; only one backing slice is used
-	// per encoding.
+	// data64 holds the ICML solution words (see icmlSolution) for w∈{64,128};
+	// nil for w=32. Only one backing slice is used per encoding.
 	data64 []uint64
 
-	// data32 backs the unpacked w=32 encoding only (nil otherwise). Retained
-	// so both w=32 encodings are queryable behind the accessor until Task 4
-	// settles the packing decision.
+	// data32 holds the ICML solution words for w=32 (unpacked); nil otherwise.
 	data32 []uint32
 
 	// numBlocks is numSlots / w — the number of ICML data blocks (excluding
@@ -184,16 +182,10 @@ func (f *filter) containsHash64(hr hashResult, w, blockIdx, offset, r, maxL uint
 	base0 := blockIdx * r
 	base1 := (blockIdx + 1) * r
 
-	switch f.enc {
-	case encW32Unpacked:
+	if f.enc == encW32 {
 		data := f.data32
 		_ = data[maxL] // BCE proof: all reads below are in [0, maxL].
-		var mask uint64
-		if w < 64 {
-			mask = (uint64(1) << w) - 1
-		} else {
-			mask = ^uint64(0)
-		}
+		mask := (uint64(1) << w) - 1 // w == 32 here
 		for j := uint32(0); j < r; j++ {
 			lo0 := uint64(data[base0+j])
 			var slice uint64
@@ -209,47 +201,26 @@ func (f *filter) containsHash64(hr hashResult, w, blockIdx, offset, r, maxL uint
 			}
 		}
 		return true
-
-	case encW32Packed:
-		data := f.data64
-		_ = data[maxL>>1] // BCE proof: highest physical uint64 index.
-		for j := uint32(0); j < r; j++ {
-			l0 := base0 + j
-			lo0 := (data[l0>>1] >> ((l0 & 1) * 32)) & 0xffffffff
-			var slice uint64
-			if offset == 0 {
-				slice = lo0
-			} else {
-				l1 := base1 + j
-				lo1 := (data[l1>>1] >> ((l1 & 1) * 32)) & 0xffffffff
-				slice = ((lo0 >> offset) | (lo1 << (w - offset))) & ((uint64(1) << w) - 1)
-			}
-			bit := bits.OnesCount64(slice&c) & 1
-			if bit != int((hr.result>>j)&1) {
-				return false
-			}
-		}
-		return true
-
-	default: // encW64
-		data := f.data64
-		_ = data[maxL] // BCE proof: all reads below are in [0, maxL].
-		for j := uint32(0); j < r; j++ {
-			lo0 := data[base0+j]
-			var slice uint64
-			if offset == 0 {
-				slice = lo0
-			} else {
-				lo1 := data[base1+j]
-				slice = (lo0 >> offset) | (lo1 << (w - offset))
-			}
-			bit := bits.OnesCount64(slice&c) & 1
-			if bit != int((hr.result>>j)&1) {
-				return false
-			}
-		}
-		return true
 	}
+
+	// encW64: logical word L → data64[L]; full 64-bit slices (no masking).
+	data := f.data64
+	_ = data[maxL] // BCE proof: all reads below are in [0, maxL].
+	for j := uint32(0); j < r; j++ {
+		lo0 := data[base0+j]
+		var slice uint64
+		if offset == 0 {
+			slice = lo0
+		} else {
+			lo1 := data[base1+j]
+			slice = (lo0 >> offset) | (lo1 << (w - offset))
+		}
+		bit := bits.OnesCount64(slice&c) & 1
+		if bit != int((hr.result>>j)&1) {
+			return false
+		}
+	}
+	return true
 }
 
 // containsHash128 is the ICML short-circuit query for ribbon width w = 128.

--- a/filter_bench_test.go
+++ b/filter_bench_test.go
@@ -155,24 +155,20 @@ func BenchmarkContains_TruePositive(b *testing.B) {
 // ---------------------------------------------------------------------------
 // 2. Contains — true negative queries (non-member keys)
 //
-// Measures the same per-query path, but all queries return false. The
-// cost should be virtually identical to true positives because the
-// full dot product is always computed before comparison.
+// Measures the same per-query path, but all queries return false. With the
+// ICML layout (paper §5.2) the query decodes the r result columns one at a
+// time and SHORT-CIRCUITS on the first mismatched column (D3), so true
+// negatives are markedly faster than true positives. This Contains path also
+// pays XXH3 (~10 ns), which narrows the relative gap versus ContainsHash.
 //
-// Reference results (Apple M3 Pro, Go 1.25.4, n=10000, -benchtime=10s):
-//
-//   Width   ns/op   B/op   allocs/op
-//   ─────   ─────   ────   ─────────
-//   w=32    30.35   0      0
-//   w=64    47.13   0      0
-//   w=128   79.18   0      0
+// Reference results (x86 Xeon Platinum, Go 1.25.x, n=10000): true-negative
+// cost is below true-positive cost because a non-member mismatches the first
+// result column with probability ~1/2 and exits early.
 //
 // Key observations:
-//   • True-negative cost ≈ true-positive cost (within ~5%) — the full
-//     GF(2) dot product is always computed before the result comparison.
-//     No early-exit branch exists.
-//   • This means adversarial workloads (all non-member queries) pay
-//     exactly the same cost as member queries — no timing side-channel.
+//   • True negatives short-circuit on the first mismatched result column, so
+//     adversarial workloads (all non-member queries) are cheaper than member
+//     queries; do not rely on this path for constant-time behaviour.
 // ---------------------------------------------------------------------------
 
 func BenchmarkContains_TrueNegative(b *testing.B) {
@@ -209,26 +205,24 @@ func BenchmarkContains_TrueNegative(b *testing.B) {
 // This is the pure "filter query" cost, useful for comparing against
 // other filter implementations that separate hashing from querying.
 //
-// Reference results (Apple M3 Pro, Go 1.25.4, n=10000, -benchtime=10s):
+// Reference results (x86 Xeon Platinum, Go 1.25.x, ICML, n=10000):
 //
 //   Width   TP ns/op   TN ns/op   B/op   allocs/op
 //   ─────   ────────   ────────   ────   ─────────
-//   w=32    12.15      12.51      0      0
-//   w=64    25.96      26.25      0      0
-//   w=128   48.99      51.63      0      0
+//   w=32    ~20.4      ~8.9       0      0
+//   w=64    ~19.2      ~8.4       0      0
+//   w=128   ~34.6      ~10.7      0      0
 //
 // Key observations:
-//   • Removes XXH3 (~25 ns) from the measured path, isolating the pure
-//     filter query: derive (0.4 ns) + dot product + comparison.
-//   • w=32: ~12.2 ns — ~16 set bits on average, ~0.76 ns per set-bit
-//     iteration (TZCNT + XOR + BLSR).
-//   • w=64: ~26.0 ns — ~32 set bits, same ~0.81 ns/bit.
-//   • w=128: ~49.0 ns — ~64 set bits across lo+hi halves, same per-bit
-//     cost. The sequential lo→hi processing adds no measurable overhead.
-//   • TP ≈ TN to within noise — confirms no early-exit optimisation.
-//   • Compare with solver's Query benchmark (37 ns for w=64): the Filter's
-//     containsHash is ~30% faster due to the BCE-padded data slice
-//     eliminating per-iteration bounds checks.
+//   • ICML decodes the r result columns one at a time (r POPCNT-based column
+//     parities) and short-circuits on the first mismatch (D3).
+//   • True positives confirm all r columns; the cost is roughly flat in w
+//     (r column parities, not ~w/2 byte XORs), so w=64 no longer costs ~2×
+//     w=32. w=128 costs more only because each column parity folds two
+//     64-bit halves.
+//   • True negatives exit on the first mismatched column (prob ~1/2 at
+//     column 0), so TN ≪ TP — the opposite of the old row-major layout,
+//     where the full dot product was always computed.
 // ---------------------------------------------------------------------------
 
 func BenchmarkContainsHash_TruePositive(b *testing.B) {

--- a/filter_test.go
+++ b/filter_test.go
@@ -476,9 +476,55 @@ func TestFilter_Accessors(t *testing.T) {
 		t.Errorf("FPRate() = %f, want %f", f.fpRate(), expectedFPR)
 	}
 
-	sol := f.data[:f.numSlots]
-	if uint32(len(sol)) != f.numSlots {
-		t.Errorf("len(SolutionData()) = %d, want %d", len(sol), f.numSlots)
+	// ICML physical store: w=128 uses data64 with 2 uint64 per logical word.
+	numBlocks := f.numSlots / f.hasher.coeffBits
+	if f.numBlocks != numBlocks {
+		t.Errorf("numBlocks = %d, want %d", f.numBlocks, numBlocks)
+	}
+	logicalWords := (numBlocks + 1) * uint32(f.hasher.resultBits)
+	wantPhysical := 2 * logicalWords // w=128
+	if uint32(len(f.data64)) != wantPhysical {
+		t.Errorf("len(data64) = %d, want %d (2*(numBlocks+1)*r)", len(f.data64), wantPhysical)
+	}
+}
+
+// TestFilter_ICMLPhysicalLen asserts the ICML logical word count and the
+// width/encoding-specific physical backing length across all widths.
+func TestFilter_ICMLPhysicalLen(t *testing.T) {
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			keys := generateKeys("icml_physlen", 1000)
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w := cfg.CoeffBits
+			numBlocks := f.numSlots / w
+			if f.numBlocks != numBlocks {
+				t.Errorf("numBlocks = %d, want %d", f.numBlocks, numBlocks)
+			}
+			logicalWords := (numBlocks + 1) * uint32(cfg.ResultBits)
+
+			switch f.enc {
+			case encW64:
+				if uint32(len(f.data64)) != logicalWords {
+					t.Errorf("w=64: len(data64)=%d, want %d", len(f.data64), logicalWords)
+				}
+			case encW128:
+				if uint32(len(f.data64)) != 2*logicalWords {
+					t.Errorf("w=128: len(data64)=%d, want %d", len(f.data64), 2*logicalWords)
+				}
+			case encW32Packed:
+				want := (logicalWords + 1) / 2
+				if uint32(len(f.data64)) != want {
+					t.Errorf("w=32 packed: len(data64)=%d, want %d", len(f.data64), want)
+				}
+			case encW32Unpacked:
+				if uint32(len(f.data32)) != logicalWords {
+					t.Errorf("w=32 unpacked: len(data32)=%d, want %d", len(f.data32), logicalWords)
+				}
+			}
+		})
 	}
 }
 
@@ -494,8 +540,14 @@ func TestFilter_Accessors_Empty(t *testing.T) {
 	if f.fpRate() != 0.0 {
 		t.Errorf("FPRate() = %f, want 0.0", f.fpRate())
 	}
-	if f.data[:f.numSlots] != nil {
-		t.Error("SolutionData() should be nil for empty filter")
+	if f.data64 != nil {
+		t.Error("data64 should be nil for empty filter")
+	}
+	if f.data32 != nil {
+		t.Error("data32 should be nil for empty filter")
+	}
+	if f.numBlocks != 0 {
+		t.Errorf("numBlocks = %d, want 0 for empty filter", f.numBlocks)
 	}
 }
 
@@ -726,6 +778,131 @@ func TestBuild_AllResultBits(t *testing.T) {
 				if !f.contains(key) {
 					t.Fatalf("false negative for key %d with r=%d", i, r)
 				}
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ICML query correctness (Task 3)
+// =============================================================================
+
+// buildICMLFilterAndOracle builds an ICML filter plus a row-major reference
+// solution (via backSubstitute over the same successfully-banded seed) so the
+// ICML query can be cross-validated against the w=32-safe oracle.
+func buildICMLFilterAndOracle(t *testing.T, cfg Config, numKeys int, prefix string) (*filter, *solution) {
+	t.Helper()
+	keys := generateKeys(prefix, numKeys)
+	f, err := buildFilter(keys, cfg)
+	if err != nil {
+		t.Fatalf("buildFilter failed: %v", err)
+	}
+	// Re-band with the winning seed to recover the bander for the oracle.
+	h := newStandardHasher(cfg.CoeffBits, f.hasher.numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+	h.setOrdinalSeed(f.seed)
+	bd := newStandardBander(f.numSlots, cfg.CoeffBits, cfg.FirstCoeffAlwaysOne)
+	hashes := make([]uint64, numKeys)
+	for i, k := range keys {
+		hashes[i] = h.keyHashString(k)
+	}
+	if !bd.addRange(hashes, h) {
+		t.Fatalf("re-band failed for %s", icmlConfigName(cfg))
+	}
+	oracle := backSubstitute(bd, cfg.ResultBits)
+	return f, oracle
+}
+
+func TestFilter_ICMLMatchesRowMajorOracle(t *testing.T) {
+	for _, cfg := range allICMLConfigs() {
+		t.Run(icmlConfigName(cfg), func(t *testing.T) {
+			const numKeys = 800
+			f, oracle := buildICMLFilterAndOracle(t, cfg, numKeys, "icml_oracle")
+			w := cfg.CoeffBits
+
+			check := func(key string) {
+				h := f.hasher.keyHashString(key)
+				hr := f.hasher.derive(h)
+				want := slowRowMajorQuery(oracle, hr.start, hr.coeffRow, w) == hr.result
+				got := f.containsHash(h)
+				if got != want {
+					t.Fatalf("key %q: containsHash=%v, oracle=%v (start=%d)",
+						key, got, want, hr.start)
+				}
+			}
+
+			for i := 0; i < numKeys; i++ {
+				check(fmt.Sprintf("icml_oracle_%d", i))
+			}
+			for i := 0; i < 5000; i++ {
+				check(fmt.Sprintf("icml_oracle_nonmember_%d", i))
+			}
+		})
+	}
+}
+
+func TestContainsHash_ShortCircuitCorrectness(t *testing.T) {
+	// The short-circuit containsHash must return identical booleans to the
+	// full (non-short-circuit) icmlQuery for positives and negatives (D3).
+	for _, cfg := range allICMLConfigs() {
+		t.Run(icmlConfigName(cfg), func(t *testing.T) {
+			const numKeys = 800
+			keys := generateKeys("icml_sc", numKeys)
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Reconstruct the ICML solution to run the full-query oracle.
+			icml := &icmlSolution{
+				data64:     f.data64,
+				data32:     f.data32,
+				numBlocks:  f.numBlocks,
+				coeffBits:  cfg.CoeffBits,
+				resultBits: f.hasher.resultBits,
+				enc:        f.enc,
+			}
+
+			check := func(key string) {
+				h := f.hasher.keyHashString(key)
+				hr := f.hasher.derive(h)
+				full := icml.icmlQuery(hr.start, hr.coeffRow) == hr.result
+				sc := f.containsHash(h)
+				if full != sc {
+					t.Fatalf("key %q: short-circuit=%v, full=%v", key, sc, full)
+				}
+			}
+			for i := 0; i < numKeys; i++ {
+				check(fmt.Sprintf("icml_sc_%d", i))
+			}
+			for i := 0; i < 5000; i++ {
+				check(fmt.Sprintf("icml_sc_nonmember_%d", i))
+			}
+		})
+	}
+}
+
+func TestContainsHash_ZeroAllocs(t *testing.T) {
+	// Automated zero-alloc gate for the ICML hot path across widths.
+	for _, cfg := range allConfigs() {
+		t.Run(configName(cfg), func(t *testing.T) {
+			const numKeys = 2000
+			keys := generateKeys("icml_alloc", numKeys)
+			f, err := buildFilter(keys, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			hashes := make([]uint64, numKeys)
+			for i, k := range keys {
+				hashes[i] = f.hasher.keyHashString(k)
+			}
+			var sink bool
+			i := 0
+			avg := testing.AllocsPerRun(1000, func() {
+				sink = f.containsHash(hashes[i%numKeys])
+				i++
+			})
+			_ = sink
+			if avg != 0 {
+				t.Errorf("containsHash allocs/op = %v, want 0", avg)
 			}
 		})
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -514,14 +514,9 @@ func TestFilter_ICMLPhysicalLen(t *testing.T) {
 				if uint32(len(f.data64)) != 2*logicalWords {
 					t.Errorf("w=128: len(data64)=%d, want %d", len(f.data64), 2*logicalWords)
 				}
-			case encW32Packed:
-				want := (logicalWords + 1) / 2
-				if uint32(len(f.data64)) != want {
-					t.Errorf("w=32 packed: len(data64)=%d, want %d", len(f.data64), want)
-				}
-			case encW32Unpacked:
+			case encW32:
 				if uint32(len(f.data32)) != logicalWords {
-					t.Errorf("w=32 unpacked: len(data32)=%d, want %d", len(f.data32), logicalWords)
+					t.Errorf("w=32: len(data32)=%d, want %d", len(f.data32), logicalWords)
 				}
 			}
 		})

--- a/ribbon.go
+++ b/ribbon.go
@@ -51,8 +51,11 @@ type Config struct {
 	//   r=8:  FPR ≈ 0.39%
 	//   r=10: FPR ≈ 0.098%
 	//
-	// Must be in [1, 8]. Limited to 8 because the solution stores one
-	// uint8 per slot (the paper calls these "result rows").
+	// Must be in [1, 8]. Limited to 8 because each key's fingerprint is a
+	// uint8 (the paper calls these "result rows"). The solution itself is
+	// NOT stored one uint8 per slot: it uses the Interleaved Column-Major
+	// Layout (paper §5.2), which packs the r result-bit columns of each
+	// w-row block into r w-bit words (see filter and icmlSolution).
 	ResultBits uint
 
 	// FirstCoeffAlwaysOne controls whether bit 0 of every coefficient row

--- a/ribbon.go
+++ b/ribbon.go
@@ -197,7 +197,7 @@ func (r *Ribbon) Build(keys []string) error {
 // Returns false if Build has not been called yet.
 //
 // This is the hot path of the library — zero allocations, branchless
-// coefficient derivation, and skip-zero dot product iteration.
+// coefficient derivation, and a short-circuiting per-column ICML query.
 func (r *Ribbon) Contains(key string) bool {
 	if r.f == nil {
 		return false

--- a/ribbon_bench_test.go
+++ b/ribbon_bench_test.go
@@ -119,11 +119,22 @@ func paperSizes(b *testing.B) []int {
 // Reports:
 //   ns/op       — total time to build a filter from n keys
 //   ns/key      — amortized per-key construction cost
-//   bits/key    — actual storage per key (simple format: 8 × numSlots / n)
+//   bits/key    — actual ICML storage per key: physical solution words × width / n
+//                 (w=64/128: len(data64)×64; w=32: len(data32)×32)
 //   overhead%   — slot overhead: (numSlots/n − 1) × 100
 //   B/op        — total bytes allocated per build
 //   allocs/op   — total heap allocations per build
 // =============================================================================
+
+// icmlStorageBits returns the actual physical storage of a filter's ICML
+// solution, in bits. w=32 uses the unpacked []uint32 store; w∈{64,128} use
+// []uint64.
+func icmlStorageBits(f *filter) float64 {
+	if f.enc == encW32 {
+		return float64(len(f.data32)) * 32
+	}
+	return float64(len(f.data64)) * 64
+}
 
 func BenchmarkPaper_Build(b *testing.B) {
 	sizes := paperSizes(b)
@@ -154,7 +165,7 @@ func BenchmarkPaper_Build(b *testing.B) {
 				if rb != nil && rb.f != nil {
 					nf := float64(n)
 					numSlots := float64(rb.f.numSlots)
-					bitsPerKey := (numSlots * 8) / nf
+					bitsPerKey := icmlStorageBits(rb.f) / nf
 					overheadPct := ((numSlots / nf) - 1) * 100
 					nsPerKey := float64(b.Elapsed().Nanoseconds()) / (float64(b.N) * nf)
 
@@ -298,8 +309,9 @@ func BenchmarkPaper_Query_Negative(b *testing.B) {
 // without timing construction, making it fast to run even at n=10^8.
 //
 // Reported metrics:
-//   bits/key         — actual storage: 8 × numSlots / n (our simple format)
-//   packed-bits/key  — theoretical with packed r-bit storage: r × numSlots / n
+//   bits/key         — actual ICML storage: physical solution words × width / n
+//                      (w=64/128: len(data64)×64; w=32: len(data32)×32)
+//   theo-bits/key    — theoretical r-bit-packed lower bound: r × numSlots / n
 //   overhead%        — slot overhead: (numSlots/n − 1) × 100
 //
 // Paper §4 theoretical bits/key (interleaved format):
@@ -339,8 +351,8 @@ func BenchmarkPaper_Space(b *testing.B) {
 				}
 				b.StopTimer()
 
-				b.ReportMetric((numSlots*8)/nf, "bits/key")
-				b.ReportMetric((numSlots*7)/nf, "packed-bits/key")
+				b.ReportMetric(icmlStorageBits(rb.f)/nf, "bits/key")
+				b.ReportMetric((numSlots*7)/nf, "theo-bits/key")
 				b.ReportMetric(((numSlots/nf)-1)*100, "overhead%")
 			})
 		}

--- a/ribbon_bench_test.go
+++ b/ribbon_bench_test.go
@@ -242,13 +242,15 @@ func BenchmarkPaper_Query_Positive(b *testing.B) {
 // Paper §6: "Negative query time" column.
 //
 // Same setup as positive queries, but probes are keys NOT in the build
-// set. The cost should be virtually identical to positive queries
-// because the full GF(2) dot product is always computed before the
-// result comparison — there is no early-exit branch.
+// set. With the ICML layout (paper §5.2) the query decodes result columns
+// one at a time and SHORT-CIRCUITS on the first mismatched column (D3), so
+// negatives are faster than positives: a non-member fails column 0 with
+// probability ~1/2 and returns immediately.
 //
-// Identical true-positive vs true-negative cost confirms there is no
-// timing side-channel: an adversary cannot distinguish member from
-// non-member queries by observing latency.
+// This is a deliberate trade-off (paper §5.2: short-circuiting is used
+// except for a compile-time fixed r ≤ 4, which this library does not do):
+// throughput on non-member-heavy workloads improves, at the cost of a
+// query-latency signal an adversary could observe.
 // =============================================================================
 
 func BenchmarkPaper_Query_Negative(b *testing.B) {

--- a/solver.go
+++ b/solver.go
@@ -15,7 +15,7 @@ import "math/bits"
 // pair, loads w consecutive solution rows, and computes the dot product
 // over GF(2) per result column.
 //
-// Memory layout:
+// Memory layout (row-major reference oracle):
 //
 // The solution is stored as one result row (uint8) per slot — matching
 // RocksDB's SimpleSolutionStorage. Each S[i] is a multi-bit value where
@@ -25,6 +25,14 @@ import "math/bits"
 // bits for that slot. Queries iterate over w slots (the ribbon width),
 // computing a dot product per result column simultaneously via branchless
 // masking.
+//
+// NOTE: as of the ICML migration (paper §5.2), row-major storage is NO
+// LONGER the query layout used by the filter. The production query path is
+// the Interleaved Column-Major Layout (icmlSolution below, queried by
+// filter.containsHash). The row-major solution + backSubstitute + query are
+// retained purely as a slow, easy-to-verify cross-validation oracle for the
+// ICML path (mirroring the slowadd/add pattern in bander.go). See
+// slowRowMajorQuery for a w=32-safe oracle that does not assume padding.
 //
 // Paper §3: the query for key x computes:
 //
@@ -318,5 +326,319 @@ func (s *solution) query(start uint32, coeffRow uint128) uint8 {
 		hi &= hi - 1
 	}
 
+	return result
+}
+
+// =============================================================================
+// ICML — Interleaved Column-Major Layout (paper §5.2, the production query
+// storage). This is RocksDB's InterleavedSolutionStorage.
+// =============================================================================
+//
+// Memory is divided into w-bit logical words, grouped into blocks of r words.
+// Block b holds the column-major layout of solution rows [b·w, b·w + w):
+//
+//	bit k of word(b, j) = Z[b·w + k].bit_j        (k ∈ [0, w), j ∈ [0, r))
+//
+// The logical word index of word(b, j) is L(b, j) = b·r + j. numBlocks =
+// numSlots / w (numSlots is a multiple of w after builder rounding). One
+// trailing zero block is allocated so a query at any valid start may read
+// word(blockIdx+1, j) unconditionally while remaining in bounds.
+//
+// Physical storage is width-specific and accessed ONLY through the logical
+// accessor pair icmlGetWord/icmlSetWord (see the icmlEncoding table below), so
+// callers use the logical index L and never touch the backing slice directly.
+//
+// Correctness anchor: the state[j] shift register maintained by backSubst64/128
+// already equals word(b, j) at the instant the reverse walk reaches row
+// i == b·w. ICML back-substitution is therefore the same reverse walk with a
+// flush of state[0..r) into word(i/w, j) whenever i % w == 0.
+
+// icmlEncoding selects the physical storage layout for a given ribbon width.
+// The two w=32 encodings are interchangeable behind the icmlGetWord/icmlSetWord
+// accessor; Task 4 benchmarks both and removes the loser.
+type icmlEncoding uint8
+
+const (
+	encW64        icmlEncoding = iota // w=64:  data64[L]
+	encW128                           // w=128: data64[2L], data64[2L+1]
+	encW32Packed                      // w=32:  two 32-bit lanes per uint64
+	encW32Unpacked                    // w=32:  data32[L]
+)
+
+// icmlW32Encoding selects the physical encoding used for w=32 ICML solutions.
+// Both packed and unpacked are supported behind the accessor so the w=32
+// packing decision (D2) can be settled empirically in Task 4.
+var icmlW32Encoding = encW32Packed
+
+// icmlEncodingFor maps a ribbon width to its ICML physical encoding.
+func icmlEncodingFor(coeffBits uint32) icmlEncoding {
+	switch coeffBits {
+	case 128:
+		return encW128
+	case 32:
+		return icmlW32Encoding
+	default: // 64
+		return encW64
+	}
+}
+
+// icmlSolution holds the ICML (Interleaved Column-Major Layout) solution — the
+// production query representation. Only one backing slice is populated per
+// encoding: data64 for w∈{64,128} and the packed w=32 variant; data32 for the
+// unpacked w=32 variant.
+type icmlSolution struct {
+	data64     []uint64 // physical store for w∈{64,128} and packed w=32
+	data32     []uint32 // physical store for unpacked w=32 only
+	numBlocks  uint32   // numSlots / w
+	coeffBits  uint32   // ribbon width w (true width — 32, 64, or 128)
+	resultBits uint     // number of fingerprint bits r (≤ 8)
+	enc        icmlEncoding
+}
+
+// newICMLSolution allocates an ICML solution with numBlocks data blocks plus
+// one trailing zero block, sized for the width-specific physical encoding.
+func newICMLSolution(numBlocks, coeffBits uint32, resultBits uint) *icmlSolution {
+	if resultBits > 8 {
+		resultBits = 8
+	}
+	enc := icmlEncodingFor(coeffBits)
+	logicalWords := (numBlocks + 1) * uint32(resultBits)
+
+	sol := &icmlSolution{
+		numBlocks:  numBlocks,
+		coeffBits:  coeffBits,
+		resultBits: resultBits,
+		enc:        enc,
+	}
+	switch enc {
+	case encW64:
+		sol.data64 = make([]uint64, logicalWords)
+	case encW128:
+		sol.data64 = make([]uint64, 2*logicalWords)
+	case encW32Packed:
+		sol.data64 = make([]uint64, (logicalWords+1)/2)
+	case encW32Unpacked:
+		sol.data32 = make([]uint32, logicalWords)
+	}
+	return sol
+}
+
+// icmlGetWord returns the logical ICML word at index L. For widths ≤ 64 the hi
+// return is always 0; for w=128 the word is (hi:lo).
+func (s *icmlSolution) icmlGetWord(L uint32) (lo, hi uint64) {
+	switch s.enc {
+	case encW64:
+		return s.data64[L], 0
+	case encW128:
+		return s.data64[2*L], s.data64[2*L+1]
+	case encW32Packed:
+		shift := (L & 1) * 32
+		return (s.data64[L>>1] >> shift) & 0xffffffff, 0
+	default: // encW32Unpacked
+		return uint64(s.data32[L]), 0
+	}
+}
+
+// icmlSetWord writes the logical ICML word at index L. It is the inverse of
+// icmlGetWord and masks so a flush of the (possibly dirty-high-bit) state[j]
+// register writes only the logical word's bits without clobbering a paired
+// 32-bit lane. All w≤64 encodings ignore hi; both w=32 encodings mask lo to 32
+// bits.
+func (s *icmlSolution) icmlSetWord(L uint32, lo, hi uint64) {
+	switch s.enc {
+	case encW64:
+		s.data64[L] = lo
+	case encW128:
+		s.data64[2*L] = lo
+		s.data64[2*L+1] = hi
+	case encW32Packed:
+		p := L >> 1
+		shift := (L & 1) * 32
+		mask := uint64(0xffffffff) << shift
+		s.data64[p] = (s.data64[p] &^ mask) | ((lo & 0xffffffff) << shift)
+	default: // encW32Unpacked
+		s.data32[L] = uint32(lo)
+	}
+}
+
+// icmlColumnSlice returns the w-bit column-j slice of solution rows
+// [start, start+w), decoded from the two logical words that straddle the block
+// boundary. For w≤64 hi is always 0.
+func (s *icmlSolution) icmlColumnSlice(start, j uint32) (lo, hi uint64) {
+	w := s.coeffBits
+	r := uint32(s.resultBits)
+	blockIdx := start / w
+	offset := start % w
+
+	lo0, hi0 := s.icmlGetWord(blockIdx*r + j)
+	lo1, hi1 := s.icmlGetWord((blockIdx+1)*r + j)
+
+	if w <= 64 {
+		if offset == 0 {
+			return lo0, 0
+		}
+		slice := (lo0 >> offset) | (lo1 << (w - offset))
+		// For w < 64, the logical word is only w bits wide; mask off any bits
+		// the left-shift pushed above bit w so the slice stays w-bit clean.
+		if w < 64 {
+			slice &= (uint64(1) << w) - 1
+		}
+		return slice, 0
+	}
+
+	// w == 128: 128-bit combine.
+	if offset == 0 {
+		return lo0, hi0
+	}
+	w0 := uint128{hi: hi0, lo: lo0}.rsh(uint(offset))
+	w1 := uint128{hi: hi1, lo: lo1}.lsh(uint(128 - offset))
+	res := w0.or(w1)
+	return res.lo, res.hi
+}
+
+// icmlQuery computes the r-bit result row by decoding the ICML solution at
+// start and taking the GF(2) dot product with coeffRow, column by column. This
+// is the FULL (non-short-circuit) query, retained as the cross-validation
+// oracle for filter.containsHash (which short-circuits per D3).
+func (s *icmlSolution) icmlQuery(start uint32, coeffRow uint128) uint8 {
+	var result uint8
+	r := uint32(s.resultBits)
+	for j := uint32(0); j < r; j++ {
+		lo, hi := s.icmlColumnSlice(start, j)
+		var bit int
+		if s.coeffBits <= 64 {
+			bit = parity64(lo & coeffRow.lo)
+		} else {
+			bit = parity128(uint128{hi: hi, lo: lo}.and(coeffRow))
+		}
+		result |= uint8(bit) << j
+	}
+	return result
+}
+
+// backSubstituteICML solves the upper-triangular banded system into the ICML
+// (Interleaved Column-Major Layout) production query representation. It is the
+// same reverse-walk algorithm as backSubstitute, but instead of writing one
+// row-major byte per slot it flushes the column-major state[j] registers into
+// logical ICML words every w rows.
+//
+// The true ribbon width w is taken as a parameter — unlike backSubstitute,
+// which infers 64 for w=32 (solver.go). numSlots must be a multiple of w
+// (guaranteed by the builder).
+func backSubstituteICML(sb *standardBander, coeffBits uint32, resultBits uint) *icmlSolution {
+	numSlots := sb.numSlots
+	if resultBits > 8 {
+		resultBits = 8
+	}
+	if numSlots == 0 {
+		return &icmlSolution{
+			numBlocks:  0,
+			coeffBits:  coeffBits,
+			resultBits: resultBits,
+			enc:        icmlEncodingFor(coeffBits),
+		}
+	}
+	if numSlots%coeffBits != 0 {
+		panic("ribbon: numSlots must be a multiple of coeffBits for ICML")
+	}
+
+	numBlocks := numSlots / coeffBits
+	sol := newICMLSolution(numBlocks, coeffBits, resultBits)
+
+	if coeffBits <= 64 {
+		backSubstICML64(sol, sb, numSlots, coeffBits, resultBits)
+	} else {
+		backSubstICML128(sol, sb, numSlots, resultBits)
+	}
+	return sol
+}
+
+// backSubstICML64 performs ICML back-substitution for ribbon width w ≤ 64.
+// Identical to backSubst64 except it flushes the column-major state registers
+// into logical ICML words at every block boundary (i % w == 0) rather than
+// writing a row-major byte per slot.
+func backSubstICML64(sol *icmlSolution, sb *standardBander, numSlots, w uint32, resultBits uint) {
+	if resultBits > 8 {
+		resultBits = 8
+	}
+	r := uint32(resultBits)
+
+	var state [8]uint64
+
+	for i := int64(numSlots) - 1; i >= 0; i-- {
+		slot := sb.getSlot(uint32(i))
+		c := slot.coeffRow.lo
+		res := slot.result
+
+		for j := uint(0); j < resultBits; j++ {
+			tmp := state[j] << 1
+			bit := parity64(tmp&c) ^ int((res>>j)&1)
+			tmp |= uint64(bit)
+			state[j] = tmp
+		}
+
+		// Flush the w-bit window into block i/w when we cross a boundary.
+		if uint32(i)%w == 0 {
+			base := (uint32(i) / w) * r
+			for j := uint32(0); j < r; j++ {
+				sol.icmlSetWord(base+j, state[j], 0)
+			}
+		}
+	}
+}
+
+// backSubstICML128 performs ICML back-substitution for ribbon width w = 128.
+// Mirrors backSubst128 with a per-block flush of the uint128 state registers.
+func backSubstICML128(sol *icmlSolution, sb *standardBander, numSlots uint32, resultBits uint) {
+	if resultBits > 8 {
+		resultBits = 8
+	}
+	r := uint32(resultBits)
+
+	var state [8]uint128
+
+	for i := int64(numSlots) - 1; i >= 0; i-- {
+		slot := sb.getSlot(uint32(i))
+		cLo := slot.coeffRow.lo
+		cHi := slot.coeffRow.hi
+		res := slot.result
+
+		for j := uint(0); j < resultBits; j++ {
+			sj := state[j]
+			tmpLo := sj.lo << 1
+			tmpHi := (sj.hi << 1) | (sj.lo >> 63)
+
+			bit := bits.OnesCount64((tmpHi&cHi)^(tmpLo&cLo))&1 ^ int((res>>j)&1)
+			tmpLo |= uint64(bit)
+
+			state[j] = uint128{hi: tmpHi, lo: tmpLo}
+		}
+
+		if uint32(i)%128 == 0 {
+			base := (uint32(i) / 128) * r
+			for j := uint32(0); j < r; j++ {
+				sol.icmlSetWord(base+j, state[j].lo, state[j].hi)
+			}
+		}
+	}
+}
+
+// slowRowMajorQuery is a w=32-SAFE reference oracle over the row-major solution
+// (backSubstitute). Unlike solution.query — which assumes 128-byte padding via
+// `_ = data[127]` and would panic on the shorter oracle data at w=32 — this
+// iterates only the true w coefficient bits and bounds-checks every read. It
+// cross-validates the ICML query path (mirrors the slowadd/add oracle pattern
+// in bander.go).
+func slowRowMajorQuery(sol *solution, start uint32, coeffRow uint128, trueW uint32) uint8 {
+	var result uint8
+	n := uint32(len(sol.data))
+	for k := uint32(0); k < trueW; k++ {
+		if coeffRow.bit(uint(k)) == 1 {
+			idx := start + k
+			if idx < n {
+				result ^= sol.data[idx]
+			}
+		}
+	}
 	return result
 }

--- a/solver.go
+++ b/solver.go
@@ -354,21 +354,19 @@ func (s *solution) query(start uint32, coeffRow uint128) uint8 {
 // flush of state[0..r) into word(i/w, j) whenever i % w == 0.
 
 // icmlEncoding selects the physical storage layout for a given ribbon width.
-// The two w=32 encodings are interchangeable behind the icmlGetWord/icmlSetWord
-// accessor; Task 4 benchmarks both and removes the loser.
+//
+// The w=32 physical encoding was decided empirically in Task 4: an "unpacked"
+// []uint32 store beat a "packed" two-lanes-per-uint64 store on the real
+// containsHash short-circuit path (x86 Xeon: 20.3 vs 30.3 ns positive, 8.8 vs
+// 11.5 ns negative). The packed encoding was removed; encW32 is the surviving
+// unpacked variant.
 type icmlEncoding uint8
 
 const (
-	encW64        icmlEncoding = iota // w=64:  data64[L]
-	encW128                           // w=128: data64[2L], data64[2L+1]
-	encW32Packed                      // w=32:  two 32-bit lanes per uint64
-	encW32Unpacked                    // w=32:  data32[L]
+	encW64  icmlEncoding = iota // w=64:  data64[L]
+	encW128                     // w=128: data64[2L], data64[2L+1]
+	encW32                      // w=32:  data32[L] (unpacked)
 )
-
-// icmlW32Encoding selects the physical encoding used for w=32 ICML solutions.
-// Both packed and unpacked are supported behind the accessor so the w=32
-// packing decision (D2) can be settled empirically in Task 4.
-var icmlW32Encoding = encW32Packed
 
 // icmlEncodingFor maps a ribbon width to its ICML physical encoding.
 func icmlEncodingFor(coeffBits uint32) icmlEncoding {
@@ -376,7 +374,7 @@ func icmlEncodingFor(coeffBits uint32) icmlEncoding {
 	case 128:
 		return encW128
 	case 32:
-		return icmlW32Encoding
+		return encW32
 	default: // 64
 		return encW64
 	}
@@ -384,11 +382,10 @@ func icmlEncodingFor(coeffBits uint32) icmlEncoding {
 
 // icmlSolution holds the ICML (Interleaved Column-Major Layout) solution — the
 // production query representation. Only one backing slice is populated per
-// encoding: data64 for w∈{64,128} and the packed w=32 variant; data32 for the
-// unpacked w=32 variant.
+// encoding: data64 for w∈{64,128}; data32 for w=32.
 type icmlSolution struct {
-	data64     []uint64 // physical store for w∈{64,128} and packed w=32
-	data32     []uint32 // physical store for unpacked w=32 only
+	data64     []uint64 // physical store for w∈{64,128}
+	data32     []uint32 // physical store for w=32
 	numBlocks  uint32   // numSlots / w
 	coeffBits  uint32   // ribbon width w (true width — 32, 64, or 128)
 	resultBits uint     // number of fingerprint bits r (≤ 8)
@@ -415,9 +412,7 @@ func newICMLSolution(numBlocks, coeffBits uint32, resultBits uint) *icmlSolution
 		sol.data64 = make([]uint64, logicalWords)
 	case encW128:
 		sol.data64 = make([]uint64, 2*logicalWords)
-	case encW32Packed:
-		sol.data64 = make([]uint64, (logicalWords+1)/2)
-	case encW32Unpacked:
+	case encW32:
 		sol.data32 = make([]uint32, logicalWords)
 	}
 	return sol
@@ -431,19 +426,15 @@ func (s *icmlSolution) icmlGetWord(L uint32) (lo, hi uint64) {
 		return s.data64[L], 0
 	case encW128:
 		return s.data64[2*L], s.data64[2*L+1]
-	case encW32Packed:
-		shift := (L & 1) * 32
-		return (s.data64[L>>1] >> shift) & 0xffffffff, 0
-	default: // encW32Unpacked
+	default: // encW32
 		return uint64(s.data32[L]), 0
 	}
 }
 
 // icmlSetWord writes the logical ICML word at index L. It is the inverse of
-// icmlGetWord and masks so a flush of the (possibly dirty-high-bit) state[j]
-// register writes only the logical word's bits without clobbering a paired
-// 32-bit lane. All w≤64 encodings ignore hi; both w=32 encodings mask lo to 32
-// bits.
+// icmlGetWord: it stores only the logical word's bits, masking the (possibly
+// dirty-high-bit) state[j] register to the physical word width. All w≤64
+// encodings ignore hi; the w=32 encoding truncates lo to 32 bits.
 func (s *icmlSolution) icmlSetWord(L uint32, lo, hi uint64) {
 	switch s.enc {
 	case encW64:
@@ -451,12 +442,7 @@ func (s *icmlSolution) icmlSetWord(L uint32, lo, hi uint64) {
 	case encW128:
 		s.data64[2*L] = lo
 		s.data64[2*L+1] = hi
-	case encW32Packed:
-		p := L >> 1
-		shift := (L & 1) * 32
-		mask := uint64(0xffffffff) << shift
-		s.data64[p] = (s.data64[p] &^ mask) | ((lo & 0xffffffff) << shift)
-	default: // encW32Unpacked
+	default: // encW32
 		s.data32[L] = uint32(lo)
 	}
 }

--- a/solver.go
+++ b/solver.go
@@ -513,9 +513,9 @@ func (s *icmlSolution) icmlQuery(start uint32, coeffRow uint128) uint8 {
 // (guaranteed by the builder).
 func backSubstituteICML(sb *standardBander, coeffBits uint32, resultBits uint) *icmlSolution {
 	numSlots := sb.numSlots
-	if resultBits > 8 {
-		resultBits = 8
-	}
+	// No clamp here: newICMLSolution and backSubstICML64/128 clamp resultBits
+	// themselves (the clamp is load-bearing for state[j] BCE), so a duplicate
+	// here would be dead.
 	if numSlots == 0 {
 		return &icmlSolution{
 			numBlocks:  0,
@@ -544,6 +544,8 @@ func backSubstituteICML(sb *standardBander, coeffBits uint32, resultBits uint) *
 // into logical ICML words at every block boundary (i % w == 0) rather than
 // writing a row-major byte per slot.
 func backSubstICML64(sol *icmlSolution, sb *standardBander, numSlots, w uint32, resultBits uint) {
+	// Keep this clamp: it is load-bearing for state[j] BCE (state is [8]uint64,
+	// so the compiler needs to prove j < 8). Do not dedupe against the caller.
 	if resultBits > 8 {
 		resultBits = 8
 	}
@@ -576,6 +578,9 @@ func backSubstICML64(sol *icmlSolution, sb *standardBander, numSlots, w uint32, 
 // backSubstICML128 performs ICML back-substitution for ribbon width w = 128.
 // Mirrors backSubst128 with a per-block flush of the uint128 state registers.
 func backSubstICML128(sol *icmlSolution, sb *standardBander, numSlots uint32, resultBits uint) {
+	// Keep this clamp: it is load-bearing for state[j] BCE (state is
+	// [8]uint128, so the compiler needs to prove j < 8). Do not dedupe against
+	// the caller.
 	if resultBits > 8 {
 		resultBits = 8
 	}

--- a/solver_bench_test.go
+++ b/solver_bench_test.go
@@ -448,3 +448,83 @@ func BenchmarkSolutionMemory(b *testing.B) {
 		}
 	}
 }
+
+// =============================================================================
+// ICML benchmarks (Task 4)
+// =============================================================================
+
+// benchBuildICMLQuery builds an ICML solution + a w=32-safe row-major oracle
+// solution and pre-computed (start, coeffRow) params for both member and
+// non-member probes. Used to compare icmlQuery vs slowRowMajorQuery.
+func benchBuildICMLQuery(w uint32, numKeys int) (*icmlSolution, *solution, []benchQueryParam, []benchQueryParam) {
+	numStarts := uint32(float64(numKeys) * 1.2)
+	numSlots := numStarts + w - 1
+	numSlots = ((numSlots + w - 1) / w) * w
+	numStarts = numSlots - w + 1
+	h := newStandardHasher(w, numStarts, 7, true)
+
+	hashes := make([]uint64, numKeys)
+	for i := 0; i < numKeys; i++ {
+		hashes[i] = h.keyHash([]byte(fmt.Sprintf("icml_bench_key_%d", i)))
+	}
+	var bd *standardBander
+	for seed := uint32(0); seed < 200; seed++ {
+		h.setOrdinalSeed(seed)
+		bd = newStandardBander(numSlots, w, true)
+		if bd.addRange(hashes, h) {
+			break
+		}
+		bd = nil
+	}
+	if bd == nil {
+		panic("benchBuildICMLQuery: banding failed")
+	}
+	icml := backSubstituteICML(bd, w, 7)
+	rowMajor := backSubstitute(bd, 7)
+
+	mkParams := func(prefix string, n int) []benchQueryParam {
+		p := make([]benchQueryParam, n)
+		for i := 0; i < n; i++ {
+			rh := h.rehash(h.keyHash([]byte(fmt.Sprintf("%s_%d", prefix, i))))
+			p[i] = benchQueryParam{start: h.getStart(rh), coeffRow: h.getCoeffRow(rh)}
+		}
+		return p
+	}
+	pos := mkParams("icml_bench_key", numKeys)
+	neg := mkParams("icml_bench_nonmember", numKeys)
+	return icml, rowMajor, pos, neg
+}
+
+// BenchmarkICMLvsRowMajor_Query compares the full ICML query (icmlQuery)
+// against the w=32-safe row-major oracle (slowRowMajorQuery) at w∈{32,64,128},
+// positive + negative. Both should report 0 allocs/op.
+func BenchmarkICMLvsRowMajor_Query(b *testing.B) {
+	const numKeys = 10000
+	for _, w := range []uint32{32, 64, 128} {
+		icml, rowMajor, pos, neg := benchBuildICMLQuery(w, numKeys)
+		for _, probe := range []struct {
+			name   string
+			params []benchQueryParam
+		}{{"positive", pos}, {"negative", neg}} {
+			p := probe.params
+			b.Run(fmt.Sprintf("ICML/w=%d/%s", w, probe.name), func(b *testing.B) {
+				b.ReportAllocs()
+				var sink uint8
+				for i := 0; i < b.N; i++ {
+					q := p[i%numKeys]
+					sink = icml.icmlQuery(q.start, q.coeffRow)
+				}
+				_ = sink
+			})
+			b.Run(fmt.Sprintf("RowMajor/w=%d/%s", w, probe.name), func(b *testing.B) {
+				b.ReportAllocs()
+				var sink uint8
+				for i := 0; i < b.N; i++ {
+					q := p[i%numKeys]
+					sink = slowRowMajorQuery(rowMajor, q.start, q.coeffRow, w)
+				}
+				_ = sink
+			})
+		}
+	}
+}

--- a/solver_bench_test.go
+++ b/solver_bench_test.go
@@ -459,7 +459,7 @@ func BenchmarkSolutionMemory(b *testing.B) {
 func benchBuildICMLQuery(w uint32, numKeys int) (*icmlSolution, *solution, []benchQueryParam, []benchQueryParam) {
 	numStarts := uint32(float64(numKeys) * 1.2)
 	numSlots := numStarts + w - 1
-	numSlots = ((numSlots + w - 1) / w) * w
+	numSlots = roundUpToMultiple(numSlots, w)
 	numStarts = numSlots - w + 1
 	h := newStandardHasher(w, numStarts, 7, true)
 

--- a/solver_test.go
+++ b/solver_test.go
@@ -774,3 +774,334 @@ func TestBackSubstitute_VerifyEquations(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// ICML (Interleaved Column-Major Layout) — Task 2 tests
+// =============================================================================
+
+// allICMLConfigs returns the full ICML correctness matrix: w∈{32,64,128} ×
+// firstCoeffAlwaysOne∈{true,false} × r∈{1,4,7,8}. Every ICML correctness/oracle
+// test iterates this (unlike allConfigs, which fixes r=7).
+func allICMLConfigs() []Config {
+	var cfgs []Config
+	for _, w := range []uint32{32, 64, 128} {
+		for _, fcao := range []bool{true, false} {
+			for _, r := range []uint{1, 4, 7, 8} {
+				cfgs = append(cfgs, Config{
+					CoeffBits:           w,
+					ResultBits:          r,
+					FirstCoeffAlwaysOne: fcao,
+				})
+			}
+		}
+	}
+	return cfgs
+}
+
+func icmlConfigName(cfg Config) string {
+	return fmt.Sprintf("w=%d/fcao=%v/r=%d", cfg.CoeffBits, cfg.FirstCoeffAlwaysOne, cfg.ResultBits)
+}
+
+// buildBandedSystem builds a solved banded system for the given config by
+// finding a seed that bands numKeys keys, rounding numSlots up to a multiple
+// of w. Returns the bander, hasher, numSlots and numStarts.
+func buildBandedSystem(t *testing.T, cfg Config, numKeys int, prefix string) (*standardBander, *standardHasher, uint32, uint32) {
+	t.Helper()
+	w := cfg.CoeffBits
+	numStarts := uint32(float64(numKeys) * 1.4)
+	if numStarts < 1 {
+		numStarts = 1
+	}
+	numSlots := numStarts + w - 1
+	numSlots = ((numSlots + w - 1) / w) * w
+	numStarts = numSlots - w + 1
+
+	h := newStandardHasher(w, numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
+	var bd *standardBander
+	for seed := uint32(0); seed < 200; seed++ {
+		h.setOrdinalSeed(seed)
+		bd = newStandardBander(numSlots, w, cfg.FirstCoeffAlwaysOne)
+		ok := true
+		for i := 0; i < numKeys; i++ {
+			kh := h.keyHash([]byte(fmt.Sprintf("%s_%d", prefix, i)))
+			if !bd.add(h.derive(kh)) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return bd, h, numSlots, numStarts
+		}
+	}
+	t.Fatalf("could not band system for %s", icmlConfigName(cfg))
+	return nil, nil, 0, 0
+}
+
+func TestBackSubstICML_MatchesRowMajor(t *testing.T) {
+	for _, cfg := range allICMLConfigs() {
+		t.Run(icmlConfigName(cfg), func(t *testing.T) {
+			w := cfg.CoeffBits
+			bd, _, numSlots, _ := buildBandedSystem(t, cfg, 300, "icml_bs")
+
+			rowMajor := backSubstitute(bd, cfg.ResultBits)
+			icml := backSubstituteICML(bd, w, cfg.ResultBits)
+
+			if icml.numBlocks != numSlots/w {
+				t.Fatalf("numBlocks=%d, want %d", icml.numBlocks, numSlots/w)
+			}
+
+			r := uint32(cfg.ResultBits)
+			// Slot-by-slot: decode every bit from ICML and compare to row-major.
+			for i := uint32(0); i < numSlots; i++ {
+				b := i / w
+				off := i % w
+				rm := rowMajor.load(i)
+				for j := uint32(0); j < r; j++ {
+					lo, hi := icml.icmlGetWord(b*r + j)
+					var got uint64
+					if off < 64 {
+						got = (lo >> off) & 1
+					} else {
+						got = (hi >> (off - 64)) & 1
+					}
+					want := uint64(rm>>j) & 1
+					if got != want {
+						t.Fatalf("slot %d col %d: ICML bit=%d, row-major bit=%d",
+							i, j, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestICMLQuery_VerifyEquations(t *testing.T) {
+	for _, cfg := range allICMLConfigs() {
+		t.Run(icmlConfigName(cfg), func(t *testing.T) {
+			w := cfg.CoeffBits
+			bd, _, numSlots, _ := buildBandedSystem(t, cfg, 300, "icml_eq")
+			icml := backSubstituteICML(bd, w, cfg.ResultBits)
+
+			// Also cross-check against the w=32-safe row-major oracle.
+			rowMajor := backSubstitute(bd, cfg.ResultBits)
+
+			for i := uint32(0); i < numSlots; i++ {
+				slot := bd.getSlot(i)
+				if slot.coeffRow.isZero() {
+					continue
+				}
+				got := icml.icmlQuery(i, slot.coeffRow)
+				if got != slot.result {
+					t.Fatalf("icmlQuery(slot %d)=%d, want result=%d", i, got, slot.result)
+				}
+				oracle := slowRowMajorQuery(rowMajor, i, slot.coeffRow, w)
+				if oracle != slot.result {
+					t.Fatalf("slowRowMajorQuery(slot %d)=%d, want result=%d", i, oracle, slot.result)
+				}
+			}
+		})
+	}
+}
+
+func TestBackSubstICML_ZeroSlots(t *testing.T) {
+	for _, w := range []uint32{32, 64, 128} {
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			bd := newStandardBander(0, w, true)
+			sol := backSubstituteICML(bd, w, 7)
+			if sol.numBlocks != 0 {
+				t.Errorf("numBlocks=%d, want 0", sol.numBlocks)
+			}
+		})
+	}
+}
+
+func TestBackSubstICML_SingleSlot(t *testing.T) {
+	// One occupied slot at index 0: 1·S[0]=1 → S[0]=1, all else 0.
+	for _, w := range []uint32{32, 64, 128} {
+		t.Run(fmt.Sprintf("w=%d", w), func(t *testing.T) {
+			numSlots := w * 2
+			slots := make([]bandingSlot, numSlots)
+			slots[0] = bandingSlot{coeffRow: uint128{lo: 1}, result: 1}
+			bd := makeBanderFromSlots(numSlots, w, slots)
+			sol := backSubstituteICML(bd, w, 1)
+
+			// word(0,0) bit 0 == 1, everything else 0.
+			lo, _ := sol.icmlGetWord(0)
+			if lo&1 != 1 {
+				t.Errorf("S[0] bit = %d, want 1", lo&1)
+			}
+			if lo&^uint64(1) != 0 {
+				t.Errorf("word(0,0) high bits set: %#x", lo)
+			}
+			lo1, hi1 := sol.icmlGetWord(uint32(1))
+			if lo1 != 0 || hi1 != 0 {
+				t.Errorf("word(1,0) not zero: lo=%#x hi=%#x", lo1, hi1)
+			}
+		})
+	}
+}
+
+// newTestICMLSolution builds an icmlSolution with an EXPLICIT encoding (so both
+// w=32 encodings can be tested deterministically regardless of the global
+// icmlW32Encoding default).
+func newTestICMLSolution(enc icmlEncoding, w, numBlocks uint32, r uint) *icmlSolution {
+	logicalWords := (numBlocks + 1) * uint32(r)
+	sol := &icmlSolution{
+		numBlocks:  numBlocks,
+		coeffBits:  w,
+		resultBits: r,
+		enc:        enc,
+	}
+	switch enc {
+	case encW128:
+		sol.data64 = make([]uint64, 2*logicalWords)
+	case encW32Packed:
+		sol.data64 = make([]uint64, (logicalWords+1)/2)
+	case encW32Unpacked:
+		sol.data32 = make([]uint32, logicalWords)
+	default:
+		sol.data64 = make([]uint64, logicalWords)
+	}
+	return sol
+}
+
+func TestICMLColumnSlice_EdgeCases(t *testing.T) {
+	// Deterministic (not random): construct a known 2-data-block solution with
+	// a single column (r=1), set word(0,0)=A, word(1,0)=B, word(2,0)=0 (the
+	// trailing zero block), and assert icmlColumnSlice combines them correctly
+	// at offset 0 (block boundary), offset 1, offset w-1 (crossing into the
+	// next block), the last valid start, and a read touching the trailing zero
+	// block — for w=32 (packed AND unpacked), w=64, w=128.
+	type wcase struct {
+		name string
+		enc  icmlEncoding
+		w    uint32
+	}
+	cases := []wcase{
+		{"w=32/packed", encW32Packed, 32},
+		{"w=32/unpacked", encW32Unpacked, 32},
+		{"w=64", encW64, 64},
+		{"w=128", encW128, 128},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.w
+			const numBlocks = 2
+			const r = uint(1)
+			sol := newTestICMLSolution(tc.enc, w, numBlocks, r)
+
+			// Choose w-bit patterns for A and B (block 0 and block 1, column 0).
+			var aLo, aHi, bLo, bHi uint64
+			switch w {
+			case 32:
+				aLo = 0xA5A5A5A5
+				bLo = 0x3C3C3C3C
+			case 64:
+				aLo = 0xA5A5A5A5F0F0F0F0
+				bLo = 0x123456789ABCDEF0
+			case 128:
+				aLo = 0xA5A5A5A5F0F0F0F0
+				aHi = 0x0F0F0F0F5A5A5A5A
+				bLo = 0x123456789ABCDEF0
+				bHi = 0x0FEDCBA987654321
+			}
+			sol.icmlSetWord(0, aLo, aHi) // word(0,0)
+			sol.icmlSetWord(1, bLo, bHi) // word(1,0)
+			// word(2,0) left zero (trailing block).
+
+			// Reference: the logical 2w-bit sequence is [A (rows 0..w-1)] then
+			// [B (rows w..2w-1)] then [0 (rows 2w..3w-1)]. icmlColumnSlice(start)
+			// returns the w-bit window rows [start, start+w).
+			wantSlice := func(start uint32) (uint64, uint64) {
+				// Build a 384-bit logical bit array conceptually; extract via
+				// per-bit reads to avoid width juggling.
+				bitAt := func(pos uint32) uint64 {
+					// pos in [0, 3w).
+					blk := pos / w
+					off := pos % w
+					var lo, hi uint64
+					switch blk {
+					case 0:
+						lo, hi = aLo, aHi
+					case 1:
+						lo, hi = bLo, bHi
+					default:
+						return 0
+					}
+					if off < 64 {
+						return (lo >> off) & 1
+					}
+					return (hi >> (off - 64)) & 1
+				}
+				var lo, hi uint64
+				for k := uint32(0); k < w; k++ {
+					b := bitAt(start + k)
+					if k < 64 {
+						lo |= b << k
+					} else {
+						hi |= b << (k - 64)
+					}
+				}
+				return lo, hi
+			}
+
+			starts := []uint32{0, 1, w - 1, w /* last valid start, offset 0 */, w + 1 /* touches trailing zero */}
+			for _, start := range starts {
+				gotLo, gotHi := sol.icmlColumnSlice(start, 0)
+				wLo, wHi := wantSlice(start)
+				if gotLo != wLo || gotHi != wHi {
+					t.Errorf("start=%d: got (%#x,%#x), want (%#x,%#x)",
+						start, gotHi, gotLo, wHi, wLo)
+				}
+			}
+		})
+	}
+}
+
+func TestICMLGetSetWord_RoundTrip(t *testing.T) {
+	// Verify icmlSetWord/icmlGetWord round-trip and that packed lanes do not
+	// clobber their pair.
+	for _, tc := range []struct {
+		name string
+		enc  icmlEncoding
+		w    uint32
+	}{
+		{"w=32/packed", encW32Packed, 32},
+		{"w=32/unpacked", encW32Unpacked, 32},
+		{"w=64", encW64, 64},
+		{"w=128", encW128, 128},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sol := newTestICMLSolution(tc.enc, tc.w, 4, 3)
+			logicalWords := (4 + 1) * uint32(3)
+			// Write distinct patterns to every logical word.
+			for L := uint32(0); L < logicalWords; L++ {
+				lo := uint64(L)*0x1000001 + 0x9E3779B97F4A7C15
+				var hi uint64
+				if tc.w == 128 {
+					hi = uint64(L)*0xDEADBEEF + 0x123456789
+				}
+				if tc.w == 32 {
+					lo &= 0xffffffff
+				}
+				sol.icmlSetWord(L, lo, hi)
+			}
+			// Read back — every word must match its masked write.
+			for L := uint32(0); L < logicalWords; L++ {
+				lo := uint64(L)*0x1000001 + 0x9E3779B97F4A7C15
+				var hi uint64
+				if tc.w == 128 {
+					hi = uint64(L)*0xDEADBEEF + 0x123456789
+				}
+				if tc.w == 32 {
+					lo &= 0xffffffff
+				}
+				gotLo, gotHi := sol.icmlGetWord(L)
+				if gotLo != lo || gotHi != hi {
+					t.Errorf("L=%d: got (%#x,%#x), want (%#x,%#x)", L, gotHi, gotLo, hi, lo)
+				}
+			}
+		})
+	}
+}

--- a/solver_test.go
+++ b/solver_test.go
@@ -813,7 +813,7 @@ func buildBandedSystem(t *testing.T, cfg Config, numKeys int, prefix string) (*s
 		numStarts = 1
 	}
 	numSlots := numStarts + w - 1
-	numSlots = ((numSlots + w - 1) / w) * w
+	numSlots = roundUpToMultiple(numSlots, w)
 	numStarts = numSlots - w + 1
 
 	h := newStandardHasher(w, numStarts, cfg.ResultBits, cfg.FirstCoeffAlwaysOne)
@@ -941,27 +941,6 @@ func TestBackSubstICML_SingleSlot(t *testing.T) {
 	}
 }
 
-// newTestICMLSolution builds an icmlSolution with an EXPLICIT encoding so the
-// accessor and slice logic can be tested deterministically per width.
-func newTestICMLSolution(enc icmlEncoding, w, numBlocks uint32, r uint) *icmlSolution {
-	logicalWords := (numBlocks + 1) * uint32(r)
-	sol := &icmlSolution{
-		numBlocks:  numBlocks,
-		coeffBits:  w,
-		resultBits: r,
-		enc:        enc,
-	}
-	switch enc {
-	case encW128:
-		sol.data64 = make([]uint64, 2*logicalWords)
-	case encW32:
-		sol.data32 = make([]uint32, logicalWords)
-	default:
-		sol.data64 = make([]uint64, logicalWords)
-	}
-	return sol
-}
-
 func TestICMLColumnSlice_EdgeCases(t *testing.T) {
 	// Deterministic (not random): construct a known 2-data-block solution with
 	// a single column (r=1), set word(0,0)=A, word(1,0)=B, word(2,0)=0 (the
@@ -985,7 +964,10 @@ func TestICMLColumnSlice_EdgeCases(t *testing.T) {
 			w := tc.w
 			const numBlocks = 2
 			const r = uint(1)
-			sol := newTestICMLSolution(tc.enc, w, numBlocks, r)
+			sol := newICMLSolution(numBlocks, w, r)
+			if sol.enc != tc.enc {
+				t.Fatalf("newICMLSolution(w=%d) enc = %v, want %v", w, sol.enc, tc.enc)
+			}
 
 			// Choose w-bit patterns for A and B (block 0 and block 1, column 0).
 			var aLo, aHi, bLo, bHi uint64
@@ -1068,7 +1050,10 @@ func TestICMLGetSetWord_RoundTrip(t *testing.T) {
 		{"w=128", encW128, 128},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			sol := newTestICMLSolution(tc.enc, tc.w, 4, 3)
+			sol := newICMLSolution(4, tc.w, 3)
+			if sol.enc != tc.enc {
+				t.Fatalf("newICMLSolution(w=%d) enc = %v, want %v", tc.w, sol.enc, tc.enc)
+			}
 			logicalWords := (4 + 1) * uint32(3)
 			// Write distinct patterns to every logical word.
 			for L := uint32(0); L < logicalWords; L++ {

--- a/solver_test.go
+++ b/solver_test.go
@@ -941,9 +941,8 @@ func TestBackSubstICML_SingleSlot(t *testing.T) {
 	}
 }
 
-// newTestICMLSolution builds an icmlSolution with an EXPLICIT encoding (so both
-// w=32 encodings can be tested deterministically regardless of the global
-// icmlW32Encoding default).
+// newTestICMLSolution builds an icmlSolution with an EXPLICIT encoding so the
+// accessor and slice logic can be tested deterministically per width.
 func newTestICMLSolution(enc icmlEncoding, w, numBlocks uint32, r uint) *icmlSolution {
 	logicalWords := (numBlocks + 1) * uint32(r)
 	sol := &icmlSolution{
@@ -955,9 +954,7 @@ func newTestICMLSolution(enc icmlEncoding, w, numBlocks uint32, r uint) *icmlSol
 	switch enc {
 	case encW128:
 		sol.data64 = make([]uint64, 2*logicalWords)
-	case encW32Packed:
-		sol.data64 = make([]uint64, (logicalWords+1)/2)
-	case encW32Unpacked:
+	case encW32:
 		sol.data32 = make([]uint32, logicalWords)
 	default:
 		sol.data64 = make([]uint64, logicalWords)
@@ -971,15 +968,14 @@ func TestICMLColumnSlice_EdgeCases(t *testing.T) {
 	// trailing zero block), and assert icmlColumnSlice combines them correctly
 	// at offset 0 (block boundary), offset 1, offset w-1 (crossing into the
 	// next block), the last valid start, and a read touching the trailing zero
-	// block — for w=32 (packed AND unpacked), w=64, w=128.
+	// block — for w=32, w=64, w=128.
 	type wcase struct {
 		name string
 		enc  icmlEncoding
 		w    uint32
 	}
 	cases := []wcase{
-		{"w=32/packed", encW32Packed, 32},
-		{"w=32/unpacked", encW32Unpacked, 32},
+		{"w=32", encW32, 32},
 		{"w=64", encW64, 64},
 		{"w=128", encW128, 128},
 	}
@@ -1067,8 +1063,7 @@ func TestICMLGetSetWord_RoundTrip(t *testing.T) {
 		enc  icmlEncoding
 		w    uint32
 	}{
-		{"w=32/packed", encW32Packed, 32},
-		{"w=32/unpacked", encW32Unpacked, 32},
+		{"w=32", encW32, 32},
 		{"w=64", encW64, 64},
 		{"w=128", encW128, 128},
 	} {


### PR DESCRIPTION
## Summary

Switch the Ribbon filter's query storage from the row-major byte-per-slot layout to the paper's **Interleaved Column-Major Layout** (ICML, Dillinger & Walzer 2021, §5.2). This is the production layout the paper's performance claims are based on: memory is divided into *w*-bit words grouped into blocks of *r* words, each block being the column-major layout of *w* contiguous rows of the solution matrix. Result: substantially lower query latency (default w=128 positive −51%, negative −67%), a tighter *r*-bits-per-slot store, and — as a side effect of that tighter store — modestly faster construction with fewer allocations.

## Changes

- **`solver.go`** — New `icmlSolution` type, `icmlEncoding` enum, and a single `icmlGetWord`/`icmlSetWord` accessor that hides all width/encoding mapping (w=64 → `data64[L]`; w=128 → `data64[2L]`/`data64[2L+1]`; w=32 → unpacked `data32[L]`). `backSubstituteICML` → `backSubstICML64`/`backSubstICML128` reuse the existing reverse-walk back-substitution, buffering *w* rows in *r* width-*w* registers and flushing once per block (every *w* rows) using the **true** width *w*. Added `icmlColumnSlice`, the full non-short-circuit `icmlQuery`, and a w=32-safe `slowRowMajorQuery` oracle. Row-major `solution`/`backSubstitute`/`query` kept as the reference oracle.
- **`filter.go`** — `filter` now stores `data64 []uint64` (+ `data32 []uint32` for w=32), `numBlocks`, and the encoding, with no query-time padding. `containsHash` rewritten to decode ICML via the two-block column combine, with **short-circuit on negative queries** (returns false on the first mismatched result column, per §5.2) and a width-specific single bounds-check-elimination proof (`containsHash64`/`containsHash128`). Hot path stays zero-allocation.
- **`builder.go`** — `numSlots` is rounded up to a multiple of *w* (via a new `roundUpToMultiple` helper) so the ICML block invariant holds; `numStarts` recomputed on the override path. Build wiring calls `backSubstituteICML`.
- **`ribbon.go`** — Doc-comment updates to reflect ICML.
- **Tests/benchmarks** — New `allICMLConfigs()` matrix (w∈{32,64,128} × firstCoeffAlwaysOne∈{true,false} × r∈{1,4,7,8}); ICML↔row-major equivalence, column-slice edge cases, short-circuit correctness, numSlots-multiple-of-w, and zero-alloc tests; `BenchmarkICMLvsRowMajor_Query`; corrected space-metric benchmarks to report actual ICML physical storage.
- **`README.md`** — Memory-layout prose, query benchmark table (re-measured on x86), and space tables updated to ICML (actual *r*-bits/slot storage; w=128 @ n=10⁶ = 7.33 bits/key, 23.6% smaller than an equivalent Bloom filter).

### Query latency 

| Benchmark | before ns/op | after ns/op | delta |
|---|---|---|---|
| Contains_TrueNegative/w=128 | 86.10 | 28.40 | −67.0% |
| Contains_TrueNegative/w=64 | 50.74 | 22.19 | −56.3% |
| Contains_TrueNegative/w=32 | 25.03 | 22.85 | −8.7% |
| Contains_TruePositive/w=128 | ~88 | ~46 | ~−47% |
| Contains_TruePositive/w=64 | ~54 | ~32 | ~−41% |
| Contains_TruePositive/w=32 (n=10k) | 29.14 | 31.66 | +8.7% |
| Paper_Query_Positive/w=128 | 88.41 | 43.04 | −51.3% |
| Paper_Query_Positive/w=64 | 54.08 | 31.29 | −42.1% |
| Paper_Query_Positive/w=32 | 27.08 | 31.76 | +17.3% |

**Known regression (expected, documented):** w=32 positive probe (~+8–23%). The tiny w=32 solution array is cache-resident, so the old skip-zero byte-XOR over ~16 set bits is very cheap, whereas ICML pays r=7 full-width column parities. It's the only regression, is inherent to the layout trade-off (the fastest w=32 encoding was already chosen empirically), and is disclosed in the README. Negatives short-circuit and win at every width; the default w=128 configuration wins on both.

### Construction throughput (side benefit)

The tighter *r*-bits-per-slot store (no per-slot byte + no +128-byte query padding) and the register-buffered per-block flush also make construction modestly faster and lower-allocation. Full `Build()`, n=10⁶, ns/key:

| Width | before | after | delta |
|---|---|---|---|
| w=32 | ~50.5 | ~44.4 | −12% |
| w=64 | ~55.1 | ~51.4 | −7% |
| w=128 | ~88.9 | ~85.2 | −4% |

Isolated back-substitution (`BenchmarkBuildFromHashes`, no hashing) improves up to −33% at small n (w=64/n=1k: 40.3µs → 27.1µs). Allocations drop by one and total bytes fall at every config (e.g. w=64/n=100k: 1,220,752 B / 6 allocs → 1,089,744 B / 5 allocs). The build win shrinks as n grows — at w=128 / large n it is roughly neutral, since banding (Gaussian elimination), which ICML does not touch, dominates construction at scale. numSlots rounding to a multiple of *w* did not change space overhead.

### Cache-line behavior 

Confirmed the paper's memory-locality model with `perf stat` (L1-dcache-load-misses proxy on this virtualized host; LLC counters are not exposed here). For the paper's exact example config **r=6, w=64**, the measured *incremental* lines-per-query of ICML over row-major is **≈0.85** vs the paper's predicted **2.25 − 1.5 = 0.75**; absolute negative-query line counts land at ICML **≈2.0** / row-major **≈1.15**, right beside the paper's 2.25 / 1.5 model, with ICML correctly sitting between row-major and a Xor filter's ~3 lines. Positive queries touch more lines than negatives because negatives short-circuit, matching §5.2.